### PR TITLE
Moar benchmarks

### DIFF
--- a/vararg-benchmark.cc
+++ b/vararg-benchmark.cc
@@ -22,6 +22,16 @@ void varargs(benchmark::State& state) {
     test_printf("%d", 42);
 }
 
+void varargs_12(benchmark::State& state) {
+  while (state.KeepRunning())
+    test_printf("%d %d %d %d "
+                "%f %f %f %f "
+                "%x %x %x %x",
+                1,    2,    3,    4,
+                1.0f, 2.0f, 3.0f, 4.0f,
+                0x1,  0x2,  0x3,  0x4);
+}
+
 BENCHMARK(varargs);
 
 void __attribute__((noinline)) test_vprint(const char *f, fmt::format_args) {
@@ -38,6 +48,16 @@ void fmt_variadic(benchmark::State &state) {
     test_print("{}", 42);
 }
 
+void fmt_variadic_12(benchmark::State &state) {
+  while (state.KeepRunning())
+    test_printf("{} {} {} {} "
+                "{} {} {} {} "
+                "{} {} {} {}",
+                1,    2,    3,    4,
+                1.0f, 2.0f, 3.0f, 4.0f,
+                0x1,  0x2,  0x3,  0x4);
+}
+
 BENCHMARK(fmt_variadic);
 
 void test_sprintf(benchmark::State &state) {
@@ -46,11 +66,32 @@ void test_sprintf(benchmark::State &state) {
     std::sprintf(buffer, "%d", 42);
 }
 
+void test_sprintf_12(benchmark::State &state) {
+  char buffer[64];
+  while (state.KeepRunning())
+    std::sprintf(buffer, "%d %d %d %d "
+                         "%f %f %f %f "
+                         "%x %x %x %x",
+                         1,    2,    3,    4,
+                         1.0f, 2.0f, 3.0f, 4.0f,
+                         0x1,  0x2,  0x3,  0x4);
+}
+
 BENCHMARK(test_sprintf);
 
 void test_format(benchmark::State &state) {
   while (state.KeepRunning())
     fmt::format("{}", 42);
+}
+
+void test_format_12(benchmark::State &state) {
+  while (state.KeepRunning())
+      fmt::format("{} {} {} {} "
+                  "{} {} {} {} "
+                  "{} {} {} {}",
+                  1,    2,    3,    4,
+                  1.0f, 2.0f, 3.0f, 4.0f,
+                  0x1,  0x2,  0x3,  0x4);
 }
 
 BENCHMARK(test_format);
@@ -61,6 +102,17 @@ void test_sprintf_pos(benchmark::State &state) {
     std::sprintf(buffer, "%1$d", 42);
 }
 
+void test_sprintf_pos_12(benchmark::State &state) {
+  char buffer[64];
+  while (state.KeepRunning())
+    std::sprintf(buffer, "%12$d %11$d %10$d %9$d "
+                         "%8$f %7$f %6$f %5$f "
+                         "%4$x %3$x %2$x %1$x",
+                         0x1,  0x2,  0x3,  0x4,
+                         1.0f, 2.0f, 3.0f, 4.0f,
+                         1,    2,    3,    4);
+}
+
 BENCHMARK(test_sprintf_pos);
 
 void test_format_pos(benchmark::State &state) {
@@ -68,6 +120,23 @@ void test_format_pos(benchmark::State &state) {
     fmt::format("{0}", 42);
 }
 
+void test_format_pos_12(benchmark::State &state) {
+  while (state.KeepRunning())
+      fmt::format("{11} {10} {9} {8} "
+                  "{7} {6} {5} {4} "
+                  "{3} {2} {1} {0}",
+                  1,    2,    3,    4,
+                  1.0f, 2.0f, 3.0f, 4.0f,
+                  0x1,  0x2,  0x3,  0x4);
+}
+
 BENCHMARK(test_format_pos);
+
+BENCHMARK(varargs_12);
+BENCHMARK(fmt_variadic_12);
+BENCHMARK(test_sprintf_12);
+BENCHMARK(test_format_12);
+BENCHMARK(test_sprintf_pos_12);
+BENCHMARK(test_format_pos_12);
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
I found the benchmarks "unfair" in the sense, that if you call the variadic libfmt functions with single parameters, they all fit nicely into registers.
This completely ignores that the old C-style varargs approach scales nicely in the sense that there is only one single function symbol in the binary which can be called with any number of arguments.
This is not the case for C++ variadic functions.

The benchmark shows interesting different numbers, when you call all benchmarked functions with 12 parameters of different types:

``` bash
Benchmark                    Time           CPU Iterations
----------------------------------------------------------
varargs                      3 ns          3 ns  214876753
fmt_variadic                 2 ns          2 ns  329446095
test_sprintf                63 ns         63 ns   10619652
test_format                 51 ns         51 ns   12738656
test_sprintf_pos           116 ns        116 ns    5911804
test_format_pos             52 ns         52 ns   12986316
varargs_12                   4 ns          4 ns  174684650
fmt_variadic_12              4 ns          4 ns  180210210
test_sprintf_12            838 ns        838 ns     810623
test_format_12            1184 ns       1184 ns     583738
test_sprintf_pos_12       1167 ns       1167 ns     593402
test_format_pos_12        1204 ns       1204 ns     582479
```

This is especially interesting for any application which prints large dumps of data from time to time, and tries to avoid binary-size-bloat at the same time.