### PR TITLE
Introduced fmt::prepare speed test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,21 +83,23 @@ if (WIN32)
 	DEPENDS tinyformat_speed_test)
 else()
   add_custom_target(speed-test
-        COMMAND @echo running speed tests...
+  COMMAND @echo running speed tests...
 	COMMAND @echo printf timings:
 	COMMAND @time -p ./tinyformat_speed_test printf > /dev/null
 	COMMAND @echo iostreams timings:
 	COMMAND @time -p ./tinyformat_speed_test iostreams > /dev/null
 	COMMAND @echo format timings:
 	COMMAND @time -p ./tinyformat_speed_test format > /dev/null
+	COMMAND @echo fmt::prepare timings:
+	COMMAND @time -p ./tinyformat_speed_test fmt::prepare > /dev/null
 	COMMAND @echo tinyformat timings:
 	COMMAND @time -p ./tinyformat_speed_test tinyformat > /dev/null
 	COMMAND @echo boost timings:
 	COMMAND @time -p ./tinyformat_speed_test boost > /dev/null
-        COMMAND @echo folly timings:
-        COMMAND @time -p ./tinyformat_speed_test folly > /dev/null
-        COMMAND @echo stb_sprintf timings:
-        COMMAND @time -p ./tinyformat_speed_test stb_sprintf > /dev/null
+  COMMAND @echo folly timings:
+  COMMAND @time -p ./tinyformat_speed_test folly > /dev/null
+  COMMAND @echo stb_sprintf timings:
+  COMMAND @time -p ./tinyformat_speed_test stb_sprintf > /dev/null
 	DEPENDS tinyformat_speed_test)
 endif()
 

--- a/find-pow10-benchmark.cc
+++ b/find-pow10-benchmark.cc
@@ -1,4 +1,5 @@
 #include <benchmark/benchmark.h>
+#include <algorithm>
 #include <random>
 #include <cmath>
 

--- a/tinyformat_test.cpp
+++ b/tinyformat_test.cpp
@@ -12,6 +12,7 @@ namespace std { class type_info; }
 #ifdef SPEED_TEST
 #ifdef HAVE_FORMAT
 # include "fmt/format.h"
+# include "fmt/prepare.h"
 #endif
 #ifdef HAVE_BOOST
 # include <boost/format.hpp>
@@ -112,6 +113,20 @@ void speedTest(const std::string& which)
         for(long i = 0; i < maxIter; ++i)
             fmt::print("{:.10f}:{:04}:{:+}:{}:{}:{}:%\n",
                 1.234, 42, 3.13, "str", (void*)1000, 'X');
+    }
+    else if(which == "fmt::prepare")
+    {
+        // format::prepare version.
+        const auto prepared_format =
+            fmt::prepare<double, int, double, const char*, void*, char>("{:.10f}:{:04}:{:+}:{}:{}:{}:%\n");
+        fmt::basic_memory_buffer<char, 1024> buffer;
+        for(long i = 0; i < maxIter; ++i)
+        {
+            auto finished_at =
+                prepared_format.format_to(buffer, 1.234, 42, 3.13, "str", (void*)1000, 'X');
+            *finished_at = '\0';
+            std::puts(buffer.data());
+        }
     }
 #endif
     else if(which == "folly")


### PR DESCRIPTION
Fixes #10 
I had to add `#include <algorithm>` in the `find-pow10-benchmark.cc`. Without it, clang++-7 could not compile the file.

Here are results of a quick run on my machine. 
```
running speed tests...
printf timings:
real 0.85
user 0.85
sys 0.00
iostreams timings:
real 1.41
user 1.40
sys 0.00
format timings:
real 0.76
user 0.76
sys 0.00
format::prepare timings:
real 0.67
user 0.65
sys 0.01
tinyformat timings:
real 1.69
user 1.68
sys 0.00
boost timings:
real 5.29
user 5.27
sys 0.01
folly timings:
folly is not available
real 0.00
user 0.00
sys 0.00
stb_sprintf timings:
real 0.62
user 0.61
sys 0.00
```
Of course that's not a proper way of benchmarking (I had chrome open etc.). Anyway, `fmt::prepare` approach is most of the time ~100ms faster than the `fmt::printf` one.