### PR TITLE
Provide benchmark of fast_io and more detailed version of benchmarking

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "benchmark"]
 	path = benchmark
 	url = https://github.com/google/benchmark.git
+[submodule "fast_io"]
+	path = fast_io
+	url = https://github.com/expnkx/fast_io

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "benchmark"]
 	path = benchmark
 	url = https://github.com/google/benchmark.git
-[submodule "fast_io"]
-	path = fast_io
-	url = https://github.com/expnkx/fast_io

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,3 +157,13 @@ target_link_libraries(find-pow10-benchmark benchmark)
 add_executable(file-int-benchmark src/file-int-benchmark.cc)
 target_link_libraries(file-int-benchmark benchmark Boost::boost fmt)
 target_compile_features(file-int-benchmark PRIVATE cxx_relaxed_constexpr)
+
+
+add_executable(int-benchmark-in-order src/int-benchmark-in-order.cc)
+target_link_libraries(int-benchmark-in-order benchmark Boost::boost fmt)
+target_compile_features(int-benchmark-in-order PRIVATE cxx_relaxed_constexpr)
+
+
+add_executable(file-int-benchmark-in-order src/int-benchmark-in-order.cc)
+target_link_libraries(file-int-benchmark-in-order benchmark Boost::boost fmt)
+target_compile_features(file-int-benchmark-in-order PRIVATE cxx_relaxed_constexpr)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.1)
 
 # Set the default CMAKE_BUILD_TYPE to Release.
 # This should be done before the project command since the latter can set
@@ -10,14 +10,15 @@ endif ()
 
 project(FORMAT_BENCHMARKS)
 
-set(CMAKE_MACOSX_RPATH ON)
-set(CMAKE_CXX_STANDARD 17)
+
+set(CMAKE_CXX_STANDARD 20)
 
 # Workaround a JCC bug in Intel CPUs:
 # https://www.intel.com/content/dam/support/us/en/documents/processors/mitigations-jump-conditional-code-erratum.pdf
 # to get more reliable benchmark results.
 set(INTEL FALSE)
 if (APPLE)
+  set(CMAKE_MACOSX_RPATH ON)
   execute_process(COMMAND sysctl -n machdep.cpu.brand_string
                   OUTPUT_VARIABLE out)
   if (out MATCHES "Intel.*")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,10 +154,6 @@ target_link_libraries(concat-benchmark benchmark fmt)
 add_executable(find-pow10-benchmark find-pow10-benchmark.cc)
 target_link_libraries(find-pow10-benchmark benchmark)
 
-add_executable(int-benchmark src/int-benchmark.cc)
-target_link_libraries(int-benchmark benchmark Boost::boost fmt)
-target_compile_features(int-benchmark PRIVATE cxx_relaxed_constexpr)
-
 add_executable(file-int-benchmark src/file-int-benchmark.cc)
 target_link_libraries(file-int-benchmark benchmark Boost::boost fmt)
 target_compile_features(file-int-benchmark PRIVATE cxx_relaxed_constexpr)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,6 @@ target_link_libraries(int-benchmark-in-order benchmark Boost::boost fmt)
 target_compile_features(int-benchmark-in-order PRIVATE cxx_relaxed_constexpr)
 
 
-add_executable(file-int-benchmark-in-order src/int-benchmark-in-order.cc)
+add_executable(file-int-benchmark-in-order src/file-int-benchmark-in-order.cc)
 target_link_libraries(file-int-benchmark-in-order benchmark Boost::boost fmt)
 target_compile_features(file-int-benchmark-in-order PRIVATE cxx_relaxed_constexpr)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,3 +153,11 @@ target_link_libraries(concat-benchmark benchmark fmt)
 
 add_executable(find-pow10-benchmark find-pow10-benchmark.cc)
 target_link_libraries(find-pow10-benchmark benchmark)
+
+add_executable(int-benchmark src/int-benchmark.cc)
+target_link_libraries(int-benchmark benchmark Boost::boost fmt)
+target_compile_features(int-benchmark PRIVATE cxx_relaxed_constexpr)
+
+add_executable(file-int-benchmark src/file-int-benchmark.cc)
+target_link_libraries(file-int-benchmark benchmark Boost::boost fmt)
+target_compile_features(file-int-benchmark PRIVATE cxx_relaxed_constexpr)

--- a/README.rst
+++ b/README.rst
@@ -50,8 +50,6 @@ Sample results on macOS with clang and libc++:
 
 Other benchmarks running on provided by fast_io author. On Linux with libstdc++, GCC-11 C++20. Running on clang + apple is bad since libc++ is extremely slow compared to libstdc++. Apple is also not mainstream platform. Think of how apple exploits workers in 3rd world.
 
-BTW, I will also provide a file benchmark to let you guys see why format_int makes no sense in real world.
-
 .. code::
 
 	cqwrteur@DESKTOP-C4VAUFM:~/format-benchmark/build$ ./int-benchmark
@@ -98,6 +96,58 @@ BTW, I will also provide a file benchmark to let you guys see why format_int mak
 	fast_io_concat          11085544 ns     11085565 ns           63 items_per_second=90.2074M/s
 	fast_io_print_reserve    9506848 ns      9506866 ns           73 items_per_second=105.187M/s
 
+
+BTW, I will also provide a file benchmark to let you guys see why format_int makes no sense in real world. format_int writes data backward, which means it can never be used for high-performance formatted I/O. It can neither in-place construct std::string.
+
+.. code::
+
+	cqwrteur@DESKTOP-C4VAUFM:~/format-benchmark/build/fileb$ ../file-int-benchmark
+	The number of values by digit count:
+	1  27518
+	2 246950
+	3 450053
+	4 247697
+	5  25016
+	6   2491
+	7    249
+	8     25
+	9      0
+	10      1
+	2020-06-21T10:25:13-04:00
+	Running ../file-int-benchmark
+	Run on (12 X 3593.26 MHz CPU s)
+	CPU Caches:
+	L1 Data 32 KiB (x6)
+	L1 Instruction 32 KiB (x6)
+	L2 Unified 512 KiB (x6)
+	L3 Unified 16384 KiB (x1)
+	Load Average: 0.00, 0.04, 0.23
+	----------------------------------------------------------------
+	Benchmark                      Time             CPU   Iterations
+	----------------------------------------------------------------
+	fprintf                 64107364 ns     64106119 ns           11
+	std_ofstream            60662327 ns     60662397 ns           11
+	fmt_print               50619350 ns     50618835 ns           14
+	std_to_chars            13745430 ns     13745453 ns           50
+	fmt_to_string           19279941 ns     19279726 ns           37
+	fmt_format_runtime      41865575 ns     41864968 ns           16
+	fmt_format_compile      22275384 ns     22275375 ns           32
+	fmt_format_to_runtime   28825158 ns     28824894 ns           24
+	fmt_format_to_compile   14296560 ns     14296560 ns           48
+	fmt_format_int          13562310 ns     13562309 ns           51
+	boost_lexical_cast      33195733 ns     33174949 ns           21
+	boost_format           241966400 ns    241964154 ns            3
+	boost_karma_generate    14441921 ns     14441750 ns           48
+	voigt_itostr            20043046 ns     20042388 ns           35
+	u2985907                13534979 ns     13534671 ns           52
+	u2985907_correct        10393649 ns     10388901 ns           67
+	std_to_chars_fast       10851778 ns     10851776 ns           64
+	decimal_from            14454558 ns     14454380 ns           48
+	stout_ltoa              22757248 ns     22757236 ns           31
+	fast_io_concat          14376316 ns     14376320 ns           49
+	fast_io_concatln        14233867 ns     14233865 ns           48
+	fast_io_print_reserve   13492135 ns     13492138 ns           51
+	fast_io_println         10339622 ns     10339623 ns           67
 
 concat benchmark
 
@@ -224,30 +274,3 @@ It looks fmt's benchmark's data set deliberately ruins cache locality of jiaendu
 	fast_io_concatln        13483156 ns     13473767 ns           52
 	fast_io_print_reserve   12277633 ns     12277631 ns           57
 	fast_io_println          6885923 ns      6885925 ns          106
-
-
-.. code::
-
-	cqwrteur@DESKTOP-C4VAUFM:~/format-benchmark/build$ ./concat-benchmark
-	2020-06-21T10:17:13-04:00
-	Running ./concat-benchmark
-	Run on (12 X 3593.26 MHz CPU s)
-	CPU Caches:
-	L1 Data 32 KiB (x6)
-	L1 Instruction 32 KiB (x6)
-	L2 Unified 512 KiB (x6)
-	L3 Unified 16384 KiB (x1)
-	Load Average: 0.14, 0.24, 0.40
-	------------------------------------------------------------
-	Benchmark                  Time             CPU   Iterations
-	------------------------------------------------------------
-	naive                   87.9 ns         87.9 ns      7922377
-	append                  61.5 ns         61.5 ns     11420470
-	appendWithReserve       42.1 ns         42.1 ns     16927493
-	format_compile          74.2 ns         74.2 ns      9445351
-	format_runtime           113 ns          113 ns      6153164
-	format_to               85.5 ns         85.5 ns      8221508
-	fast_io_print           22.6 ns         22.6 ns     30832719
-	fast_io_concat          65.8 ns         65.8 ns     10479647
-	nullop                 0.254 ns        0.254 ns   1000000000
-

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,9 @@ Sample results on macOS with clang and libc++:
 
 
 
-Other benchmarks running on provided by fast_io author. On Linux with libstdc++, GCC-11 C++20
+Other benchmarks running on provided by fast_io author. On Linux with libstdc++, GCC-11 C++20. Running on clang + apple is bad.
+
+BTW, I will also provide a file benchmark to let you guys see why format_int makes no sense in real world.
 
 cqwrteur@DESKTOP-C4VAUFM:~/format-benchmark/build$ ./int-benchmark
 The number of values by digit count:
@@ -121,7 +123,7 @@ fast_io_concat          66.4 ns         66.4 ns     10546989
 nullop                 0.252 ns        0.252 ns   1000000000
 
 
-It looks fmt's benchmark deliberately ruins cache locality of jiaendu algorithm
+It looks fmt's benchmark's data set deliberately ruins cache locality of jiaendu algorithm to promote his fmt lib. See this int benchmark in order. You can see jiaendu runs very well.
 
 
 cqwrteur@DESKTOP-C4VAUFM:~/format-benchmark/build$ ./int-benchmark-in-order
@@ -168,4 +170,77 @@ stout_ltoa              26098837 ns     26098883 ns           27 items_per_secon
 fast_io_concat          10248196 ns     10248215 ns           68 items_per_second=97.578M/s
 fast_io_print_reserve    5300714 ns      5300725 ns          133 items_per_second=188.653M/s
 
+
+
+cqwrteur@DESKTOP-C4VAUFM:~/format-benchmark/build/fileb$ ../file-int-benchmark-in-order
+The number of values by digit count:
+ 1     10
+ 2     90
+ 3    900
+ 4   9000
+ 5  90000
+ 6 900000
+ 7      0
+ 8      0
+ 9      0
+10      0
+2020-06-21T10:14:33-04:00
+Running ../file-int-benchmark-in-order
+Run on (12 X 3593.26 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x6)
+  L1 Instruction 32 KiB (x6)
+  L2 Unified 512 KiB (x6)
+  L3 Unified 16384 KiB (x1)
+Load Average: 0.18, 0.17, 0.40
+----------------------------------------------------------------
+Benchmark                      Time             CPU   Iterations
+----------------------------------------------------------------
+fprintf                 57592333 ns     57592426 ns           12
+std_ofstream            55919308 ns     55919377 ns           12
+fmt_print               42610800 ns     42610357 ns           17
+std_to_chars            11397534 ns     11397338 ns           62
+fmt_to_string           16661595 ns     16661393 ns           42
+fmt_format_runtime      35192181 ns     35191612 ns           21
+fmt_format_compile      19402943 ns     19402683 ns           35
+fmt_format_to_runtime   26155774 ns     26139605 ns           27
+fmt_format_to_compile   11257168 ns     11256815 ns           59
+fmt_format_int          11861714 ns     11861545 ns           59
+boost_lexical_cast      29049683 ns     29049091 ns           23
+boost_format           241224867 ns    241225457 ns            3
+boost_karma_generate    16753700 ns     16753511 ns           42
+voigt_itostr            18430816 ns     18430585 ns           37
+u2985907                10755685 ns     10755565 ns           66
+u2985907_correct         7280822 ns      7280711 ns           93
+std_to_chars_fast        8932342 ns      8932051 ns           80
+decimal_from            14453468 ns     14453466 ns           47
+stout_ltoa              30093805 ns     30093804 ns           22
+fast_io_concat          14463548 ns     14463376 ns           48
+fast_io_concatln        13483156 ns     13473767 ns           52
+fast_io_print_reserve   12277633 ns     12277631 ns           57
+fast_io_println          6885923 ns      6885925 ns          106
+
+
+cqwrteur@DESKTOP-C4VAUFM:~/format-benchmark/build$ ./concat-benchmark
+2020-06-21T10:17:13-04:00
+Running ./concat-benchmark
+Run on (12 X 3593.26 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x6)
+  L1 Instruction 32 KiB (x6)
+  L2 Unified 512 KiB (x6)
+  L3 Unified 16384 KiB (x1)
+Load Average: 0.14, 0.24, 0.40
+------------------------------------------------------------
+Benchmark                  Time             CPU   Iterations
+------------------------------------------------------------
+naive                   87.9 ns         87.9 ns      7922377
+append                  61.5 ns         61.5 ns     11420470
+appendWithReserve       42.1 ns         42.1 ns     16927493
+format_compile          74.2 ns         74.2 ns      9445351
+format_runtime           113 ns          113 ns      6153164
+format_to               85.5 ns         85.5 ns      8221508
+fast_io_print           22.6 ns         22.6 ns     30832719
+fast_io_concat          65.8 ns         65.8 ns     10479647
+nullop                 0.254 ns        0.254 ns   1000000000
 

--- a/README.rst
+++ b/README.rst
@@ -46,3 +46,76 @@ Sample results on macOS with clang and libc++:
 	decimal_from           10555579 ns     10549531 ns           64 items_per_second=94.7909M/s
 	stout_ltoa             40028853 ns     40010824 ns           17 items_per_second=24.9932M/s
 
+
+
+Other benchmarks running on provided by fast_io author. On Linux with libstdc++, GCC-11 C++20
+
+cqwrteur@DESKTOP-C4VAUFM:~/format-benchmark/build$ ./int-benchmark
+The number of values by digit count:
+ 1  27518
+ 2 246950
+ 3 450053
+ 4 247697
+ 5  25016
+ 6   2491
+ 7    249
+ 8     25
+ 9      0
+10      1
+2020-06-21T08:21:27-04:00
+Running ./int-benchmark
+Run on (12 X 3593.26 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x6)
+  L1 Instruction 32 KiB (x6)
+  L2 Unified 512 KiB (x6)
+  L3 Unified 16384 KiB (x1)
+Load Average: 0.31, 0.09, 0.17
+--------------------------------------------------------------------------------
+Benchmark                      Time             CPU   Iterations UserCounters...
+--------------------------------------------------------------------------------
+sprintf                 66180655 ns     66180815 ns           11 items_per_second=15.1101M/s
+std_ostringstream       59197433 ns     59196831 ns           12 items_per_second=16.8928M/s
+std_to_string           14227102 ns     14226740 ns           49 items_per_second=70.2902M/s
+std_to_chars            10778731 ns     10778754 ns           64 items_per_second=92.7751M/s
+fmt_to_string           15449511 ns     15449548 ns           46 items_per_second=64.7268M/s
+fmt_format_runtime      25347564 ns     25347609 ns           28 items_per_second=39.4515M/s
+fmt_format_compile      15521973 ns     15522015 ns           45 items_per_second=64.4246M/s
+fmt_format_to_runtime   19493339 ns     19493384 ns           36 items_per_second=51.2995M/s
+fmt_format_to_compile   11964826 ns     11964854 ns           58 items_per_second=83.5781M/s
+fmt_format_int           9702564 ns      9702586 ns           72 items_per_second=103.065M/s
+boost_lexical_cast      29437537 ns     29437599 ns           24 items_per_second=33.9702M/s
+boost_format           259534333 ns    259534899 ns            3 items_per_second=3.85305M/s
+boost_karma_generate    10422500 ns     10422529 ns           67 items_per_second=95.946M/s
+voigt_itostr            16333445 ns     16333491 ns           42 items_per_second=61.2239M/s
+u2985907                10527758 ns     10527785 ns           66 items_per_second=94.9867M/s
+decimal_from            11788081 ns     11788109 ns           59 items_per_second=84.8312M/s
+stout_ltoa              21071739 ns     21071791 ns           33 items_per_second=47.4568M/s
+fast_io_concat          11085544 ns     11085565 ns           63 items_per_second=90.2074M/s
+fast_io_print_reserve    9506848 ns      9506866 ns           73 items_per_second=105.187M/s
+
+
+concat benchmark
+
+cqwrteur@DESKTOP-C4VAUFM:~/format-benchmark/build$ ./concat-benchmark
+2020-06-21T08:49:23-04:00
+Running ./concat-benchmark
+Run on (12 X 3593.26 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x6)
+  L1 Instruction 32 KiB (x6)
+  L2 Unified 512 KiB (x6)
+  L3 Unified 16384 KiB (x1)
+Load Average: 1.65, 1.57, 0.68
+------------------------------------------------------------
+Benchmark                  Time             CPU   Iterations
+------------------------------------------------------------
+naive                   87.3 ns         87.3 ns      7980351
+append                  61.1 ns         61.1 ns     11319732
+appendWithReserve       41.8 ns         41.8 ns     16762382
+format_compile          74.8 ns         74.8 ns      9358126
+format_runtime           112 ns          112 ns      6235314
+format_to               84.3 ns         84.3 ns      8146667
+fast_io_print           23.3 ns         23.3 ns     30091614
+fast_io_concat          66.4 ns         66.4 ns     10546989
+nullop                 0.252 ns        0.252 ns   1000000000

--- a/README.rst
+++ b/README.rst
@@ -119,3 +119,53 @@ format_to               84.3 ns         84.3 ns      8146667
 fast_io_print           23.3 ns         23.3 ns     30091614
 fast_io_concat          66.4 ns         66.4 ns     10546989
 nullop                 0.252 ns        0.252 ns   1000000000
+
+
+It looks fmt's benchmark deliberately ruins cache locality of jiaendu algorithm
+
+
+cqwrteur@DESKTOP-C4VAUFM:~/format-benchmark/build$ ./int-benchmark-in-order
+The number of values by digit count:
+ 1     10
+ 2     90
+ 3    900
+ 4   9000
+ 5  90000
+ 6 900000
+ 7      0
+ 8      0
+ 9      0
+10      0
+2020-06-21T10:08:22-04:00
+Running ./int-benchmark-in-order
+Run on (12 X 3593.26 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x6)
+  L1 Instruction 32 KiB (x6)
+  L2 Unified 512 KiB (x6)
+  L3 Unified 16384 KiB (x1)
+Load Average: 0.42, 0.28, 0.55
+--------------------------------------------------------------------------------
+Benchmark                      Time             CPU   Iterations UserCounters...
+--------------------------------------------------------------------------------
+sprintf                 62320291 ns     62320479 ns           11 items_per_second=16.0461M/s
+std_ostringstream       54647454 ns     54646801 ns           13 items_per_second=18.2993M/s
+std_to_string            9350224 ns      9350126 ns           75 items_per_second=106.95M/s
+std_to_chars             7519653 ns      7519667 ns           93 items_per_second=132.985M/s
+fmt_to_string           11011169 ns     11011201 ns           62 items_per_second=90.8166M/s
+fmt_format_runtime      22369400 ns     22369443 ns           31 items_per_second=44.7038M/s
+fmt_format_compile      11017577 ns     11017598 ns           64 items_per_second=90.7639M/s
+fmt_format_to_runtime   17233278 ns     17233323 ns           40 items_per_second=58.0271M/s
+fmt_format_to_compile    7646626 ns      7646645 ns           92 items_per_second=130.776M/s
+fmt_format_int           5806645 ns      5806657 ns          121 items_per_second=172.216M/s
+boost_lexical_cast      24628418 ns     24628471 ns           28 items_per_second=40.6034M/s
+boost_format           226440000 ns    226440589 ns            3 items_per_second=4.41617M/s
+boost_karma_generate     9217050 ns      9217077 ns           76 items_per_second=108.494M/s
+voigt_itostr            10767260 ns     10767286 ns           65 items_per_second=92.8739M/s
+u2985907                 4781043 ns      4781053 ns          147 items_per_second=209.159M/s
+decimal_from            10713470 ns     10713493 ns           66 items_per_second=93.3402M/s
+stout_ltoa              26098837 ns     26098883 ns           27 items_per_second=38.3158M/s
+fast_io_concat          10248196 ns     10248215 ns           68 items_per_second=97.578M/s
+fast_io_print_reserve    5300714 ns      5300725 ns          133 items_per_second=188.653M/s
+
+

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Sample results on macOS with clang and libc++:
 
 
 
-Other benchmarks running on provided by fast_io author. On Linux with libstdc++, GCC-11 C++20. Running on clang + apple is bad.
+Other benchmarks running on provided by fast_io author. On Linux with libstdc++, GCC-11 C++20. Running on clang + apple is bad since libc++ is extremely slow compared to libstdc++. Apple is also not mainstream platform. Think of how apple exploits workers in 3rd world.
 
 BTW, I will also provide a file benchmark to let you guys see why format_int makes no sense in real world.
 

--- a/README.rst
+++ b/README.rst
@@ -52,195 +52,202 @@ Other benchmarks running on provided by fast_io author. On Linux with libstdc++,
 
 BTW, I will also provide a file benchmark to let you guys see why format_int makes no sense in real world.
 
-cqwrteur@DESKTOP-C4VAUFM:~/format-benchmark/build$ ./int-benchmark
-The number of values by digit count:
- 1  27518
- 2 246950
- 3 450053
- 4 247697
- 5  25016
- 6   2491
- 7    249
- 8     25
- 9      0
-10      1
-2020-06-21T08:21:27-04:00
-Running ./int-benchmark
-Run on (12 X 3593.26 MHz CPU s)
-CPU Caches:
-  L1 Data 32 KiB (x6)
-  L1 Instruction 32 KiB (x6)
-  L2 Unified 512 KiB (x6)
-  L3 Unified 16384 KiB (x1)
-Load Average: 0.31, 0.09, 0.17
---------------------------------------------------------------------------------
-Benchmark                      Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------
-sprintf                 66180655 ns     66180815 ns           11 items_per_second=15.1101M/s
-std_ostringstream       59197433 ns     59196831 ns           12 items_per_second=16.8928M/s
-std_to_string           14227102 ns     14226740 ns           49 items_per_second=70.2902M/s
-std_to_chars            10778731 ns     10778754 ns           64 items_per_second=92.7751M/s
-fmt_to_string           15449511 ns     15449548 ns           46 items_per_second=64.7268M/s
-fmt_format_runtime      25347564 ns     25347609 ns           28 items_per_second=39.4515M/s
-fmt_format_compile      15521973 ns     15522015 ns           45 items_per_second=64.4246M/s
-fmt_format_to_runtime   19493339 ns     19493384 ns           36 items_per_second=51.2995M/s
-fmt_format_to_compile   11964826 ns     11964854 ns           58 items_per_second=83.5781M/s
-fmt_format_int           9702564 ns      9702586 ns           72 items_per_second=103.065M/s
-boost_lexical_cast      29437537 ns     29437599 ns           24 items_per_second=33.9702M/s
-boost_format           259534333 ns    259534899 ns            3 items_per_second=3.85305M/s
-boost_karma_generate    10422500 ns     10422529 ns           67 items_per_second=95.946M/s
-voigt_itostr            16333445 ns     16333491 ns           42 items_per_second=61.2239M/s
-u2985907                10527758 ns     10527785 ns           66 items_per_second=94.9867M/s
-decimal_from            11788081 ns     11788109 ns           59 items_per_second=84.8312M/s
-stout_ltoa              21071739 ns     21071791 ns           33 items_per_second=47.4568M/s
-fast_io_concat          11085544 ns     11085565 ns           63 items_per_second=90.2074M/s
-fast_io_print_reserve    9506848 ns      9506866 ns           73 items_per_second=105.187M/s
+.. code::
+
+	cqwrteur@DESKTOP-C4VAUFM:~/format-benchmark/build$ ./int-benchmark
+	The number of values by digit count:
+	1  27518
+	2 246950
+	3 450053
+	4 247697
+	5  25016
+	6   2491
+	7    249
+	8     25
+	9      0
+	10      1
+	2020-06-21T08:21:27-04:00
+	Running ./int-benchmark
+	Run on (12 X 3593.26 MHz CPU s)
+	CPU Caches:
+	L1 Data 32 KiB (x6)
+	L1 Instruction 32 KiB (x6)
+	L2 Unified 512 KiB (x6)
+	L3 Unified 16384 KiB (x1)
+	Load Average: 0.31, 0.09, 0.17
+	--------------------------------------------------------------------------------
+	Benchmark                      Time             CPU   Iterations UserCounters...
+	--------------------------------------------------------------------------------
+	sprintf                 66180655 ns     66180815 ns           11 items_per_second=15.1101M/s
+	std_ostringstream       59197433 ns     59196831 ns           12 items_per_second=16.8928M/s
+	std_to_string           14227102 ns     14226740 ns           49 items_per_second=70.2902M/s
+	std_to_chars            10778731 ns     10778754 ns           64 items_per_second=92.7751M/s
+	fmt_to_string           15449511 ns     15449548 ns           46 items_per_second=64.7268M/s
+	fmt_format_runtime      25347564 ns     25347609 ns           28 items_per_second=39.4515M/s
+	fmt_format_compile      15521973 ns     15522015 ns           45 items_per_second=64.4246M/s
+	fmt_format_to_runtime   19493339 ns     19493384 ns           36 items_per_second=51.2995M/s
+	fmt_format_to_compile   11964826 ns     11964854 ns           58 items_per_second=83.5781M/s
+	fmt_format_int           9702564 ns      9702586 ns           72 items_per_second=103.065M/s
+	boost_lexical_cast      29437537 ns     29437599 ns           24 items_per_second=33.9702M/s
+	boost_format           259534333 ns    259534899 ns            3 items_per_second=3.85305M/s
+	boost_karma_generate    10422500 ns     10422529 ns           67 items_per_second=95.946M/s
+	voigt_itostr            16333445 ns     16333491 ns           42 items_per_second=61.2239M/s
+	u2985907                10527758 ns     10527785 ns           66 items_per_second=94.9867M/s
+	decimal_from            11788081 ns     11788109 ns           59 items_per_second=84.8312M/s
+	stout_ltoa              21071739 ns     21071791 ns           33 items_per_second=47.4568M/s
+	fast_io_concat          11085544 ns     11085565 ns           63 items_per_second=90.2074M/s
+	fast_io_print_reserve    9506848 ns      9506866 ns           73 items_per_second=105.187M/s
 
 
 concat benchmark
 
-cqwrteur@DESKTOP-C4VAUFM:~/format-benchmark/build$ ./concat-benchmark
-2020-06-21T08:49:23-04:00
-Running ./concat-benchmark
-Run on (12 X 3593.26 MHz CPU s)
-CPU Caches:
-  L1 Data 32 KiB (x6)
-  L1 Instruction 32 KiB (x6)
-  L2 Unified 512 KiB (x6)
-  L3 Unified 16384 KiB (x1)
-Load Average: 1.65, 1.57, 0.68
-------------------------------------------------------------
-Benchmark                  Time             CPU   Iterations
-------------------------------------------------------------
-naive                   87.3 ns         87.3 ns      7980351
-append                  61.1 ns         61.1 ns     11319732
-appendWithReserve       41.8 ns         41.8 ns     16762382
-format_compile          74.8 ns         74.8 ns      9358126
-format_runtime           112 ns          112 ns      6235314
-format_to               84.3 ns         84.3 ns      8146667
-fast_io_print           23.3 ns         23.3 ns     30091614
-fast_io_concat          66.4 ns         66.4 ns     10546989
-nullop                 0.252 ns        0.252 ns   1000000000
+.. code::
+	cqwrteur@DESKTOP-C4VAUFM:~/format-benchmark/build$ ./concat-benchmark
+	2020-06-21T08:49:23-04:00
+	Running ./concat-benchmark
+	Run on (12 X 3593.26 MHz CPU s)
+	CPU Caches:
+	L1 Data 32 KiB (x6)
+	L1 Instruction 32 KiB (x6)
+	L2 Unified 512 KiB (x6)
+	L3 Unified 16384 KiB (x1)
+	Load Average: 1.65, 1.57, 0.68
+	------------------------------------------------------------
+	Benchmark                  Time             CPU   Iterations
+	------------------------------------------------------------
+	naive                   87.3 ns         87.3 ns      7980351
+	append                  61.1 ns         61.1 ns     11319732
+	appendWithReserve       41.8 ns         41.8 ns     16762382
+	format_compile          74.8 ns         74.8 ns      9358126
+	format_runtime           112 ns          112 ns      6235314
+	format_to               84.3 ns         84.3 ns      8146667
+	fast_io_print           23.3 ns         23.3 ns     30091614
+	fast_io_concat          66.4 ns         66.4 ns     10546989
+	nullop                 0.252 ns        0.252 ns   1000000000
 
 
 It looks fmt's benchmark's data set deliberately ruins cache locality of jiaendu algorithm to promote his fmt lib. See this int benchmark in order. You can see jiaendu runs very well.
 
+.. code::
 
-cqwrteur@DESKTOP-C4VAUFM:~/format-benchmark/build$ ./int-benchmark-in-order
-The number of values by digit count:
- 1     10
- 2     90
- 3    900
- 4   9000
- 5  90000
- 6 900000
- 7      0
- 8      0
- 9      0
-10      0
-2020-06-21T10:08:22-04:00
-Running ./int-benchmark-in-order
-Run on (12 X 3593.26 MHz CPU s)
-CPU Caches:
-  L1 Data 32 KiB (x6)
-  L1 Instruction 32 KiB (x6)
-  L2 Unified 512 KiB (x6)
-  L3 Unified 16384 KiB (x1)
-Load Average: 0.42, 0.28, 0.55
---------------------------------------------------------------------------------
-Benchmark                      Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------
-sprintf                 62320291 ns     62320479 ns           11 items_per_second=16.0461M/s
-std_ostringstream       54647454 ns     54646801 ns           13 items_per_second=18.2993M/s
-std_to_string            9350224 ns      9350126 ns           75 items_per_second=106.95M/s
-std_to_chars             7519653 ns      7519667 ns           93 items_per_second=132.985M/s
-fmt_to_string           11011169 ns     11011201 ns           62 items_per_second=90.8166M/s
-fmt_format_runtime      22369400 ns     22369443 ns           31 items_per_second=44.7038M/s
-fmt_format_compile      11017577 ns     11017598 ns           64 items_per_second=90.7639M/s
-fmt_format_to_runtime   17233278 ns     17233323 ns           40 items_per_second=58.0271M/s
-fmt_format_to_compile    7646626 ns      7646645 ns           92 items_per_second=130.776M/s
-fmt_format_int           5806645 ns      5806657 ns          121 items_per_second=172.216M/s
-boost_lexical_cast      24628418 ns     24628471 ns           28 items_per_second=40.6034M/s
-boost_format           226440000 ns    226440589 ns            3 items_per_second=4.41617M/s
-boost_karma_generate     9217050 ns      9217077 ns           76 items_per_second=108.494M/s
-voigt_itostr            10767260 ns     10767286 ns           65 items_per_second=92.8739M/s
-u2985907                 4781043 ns      4781053 ns          147 items_per_second=209.159M/s
-decimal_from            10713470 ns     10713493 ns           66 items_per_second=93.3402M/s
-stout_ltoa              26098837 ns     26098883 ns           27 items_per_second=38.3158M/s
-fast_io_concat          10248196 ns     10248215 ns           68 items_per_second=97.578M/s
-fast_io_print_reserve    5300714 ns      5300725 ns          133 items_per_second=188.653M/s
-
-
-
-cqwrteur@DESKTOP-C4VAUFM:~/format-benchmark/build/fileb$ ../file-int-benchmark-in-order
-The number of values by digit count:
- 1     10
- 2     90
- 3    900
- 4   9000
- 5  90000
- 6 900000
- 7      0
- 8      0
- 9      0
-10      0
-2020-06-21T10:14:33-04:00
-Running ../file-int-benchmark-in-order
-Run on (12 X 3593.26 MHz CPU s)
-CPU Caches:
-  L1 Data 32 KiB (x6)
-  L1 Instruction 32 KiB (x6)
-  L2 Unified 512 KiB (x6)
-  L3 Unified 16384 KiB (x1)
-Load Average: 0.18, 0.17, 0.40
-----------------------------------------------------------------
-Benchmark                      Time             CPU   Iterations
-----------------------------------------------------------------
-fprintf                 57592333 ns     57592426 ns           12
-std_ofstream            55919308 ns     55919377 ns           12
-fmt_print               42610800 ns     42610357 ns           17
-std_to_chars            11397534 ns     11397338 ns           62
-fmt_to_string           16661595 ns     16661393 ns           42
-fmt_format_runtime      35192181 ns     35191612 ns           21
-fmt_format_compile      19402943 ns     19402683 ns           35
-fmt_format_to_runtime   26155774 ns     26139605 ns           27
-fmt_format_to_compile   11257168 ns     11256815 ns           59
-fmt_format_int          11861714 ns     11861545 ns           59
-boost_lexical_cast      29049683 ns     29049091 ns           23
-boost_format           241224867 ns    241225457 ns            3
-boost_karma_generate    16753700 ns     16753511 ns           42
-voigt_itostr            18430816 ns     18430585 ns           37
-u2985907                10755685 ns     10755565 ns           66
-u2985907_correct         7280822 ns      7280711 ns           93
-std_to_chars_fast        8932342 ns      8932051 ns           80
-decimal_from            14453468 ns     14453466 ns           47
-stout_ltoa              30093805 ns     30093804 ns           22
-fast_io_concat          14463548 ns     14463376 ns           48
-fast_io_concatln        13483156 ns     13473767 ns           52
-fast_io_print_reserve   12277633 ns     12277631 ns           57
-fast_io_println          6885923 ns      6885925 ns          106
+	cqwrteur@DESKTOP-C4VAUFM:~/format-benchmark/build$ ./int-benchmark-in-order
+	The number of values by digit count:
+	1     10
+	2     90
+	3    900
+	4   9000
+	5  90000
+	6 900000
+	7      0
+	8      0
+	9      0
+	10      0
+	2020-06-21T10:08:22-04:00
+	Running ./int-benchmark-in-order
+	Run on (12 X 3593.26 MHz CPU s)
+	CPU Caches:
+	L1 Data 32 KiB (x6)
+	L1 Instruction 32 KiB (x6)
+	L2 Unified 512 KiB (x6)
+	L3 Unified 16384 KiB (x1)
+	Load Average: 0.42, 0.28, 0.55
+	--------------------------------------------------------------------------------
+	Benchmark                      Time             CPU   Iterations UserCounters...
+	--------------------------------------------------------------------------------
+	sprintf                 62320291 ns     62320479 ns           11 items_per_second=16.0461M/s
+	std_ostringstream       54647454 ns     54646801 ns           13 items_per_second=18.2993M/s
+	std_to_string            9350224 ns      9350126 ns           75 items_per_second=106.95M/s
+	std_to_chars             7519653 ns      7519667 ns           93 items_per_second=132.985M/s
+	fmt_to_string           11011169 ns     11011201 ns           62 items_per_second=90.8166M/s
+	fmt_format_runtime      22369400 ns     22369443 ns           31 items_per_second=44.7038M/s
+	fmt_format_compile      11017577 ns     11017598 ns           64 items_per_second=90.7639M/s
+	fmt_format_to_runtime   17233278 ns     17233323 ns           40 items_per_second=58.0271M/s
+	fmt_format_to_compile    7646626 ns      7646645 ns           92 items_per_second=130.776M/s
+	fmt_format_int           5806645 ns      5806657 ns          121 items_per_second=172.216M/s
+	boost_lexical_cast      24628418 ns     24628471 ns           28 items_per_second=40.6034M/s
+	boost_format           226440000 ns    226440589 ns            3 items_per_second=4.41617M/s
+	boost_karma_generate     9217050 ns      9217077 ns           76 items_per_second=108.494M/s
+	voigt_itostr            10767260 ns     10767286 ns           65 items_per_second=92.8739M/s
+	u2985907                 4781043 ns      4781053 ns          147 items_per_second=209.159M/s
+	decimal_from            10713470 ns     10713493 ns           66 items_per_second=93.3402M/s
+	stout_ltoa              26098837 ns     26098883 ns           27 items_per_second=38.3158M/s
+	fast_io_concat          10248196 ns     10248215 ns           68 items_per_second=97.578M/s
+	fast_io_print_reserve    5300714 ns      5300725 ns          133 items_per_second=188.653M/s
 
 
-cqwrteur@DESKTOP-C4VAUFM:~/format-benchmark/build$ ./concat-benchmark
-2020-06-21T10:17:13-04:00
-Running ./concat-benchmark
-Run on (12 X 3593.26 MHz CPU s)
-CPU Caches:
-  L1 Data 32 KiB (x6)
-  L1 Instruction 32 KiB (x6)
-  L2 Unified 512 KiB (x6)
-  L3 Unified 16384 KiB (x1)
-Load Average: 0.14, 0.24, 0.40
-------------------------------------------------------------
-Benchmark                  Time             CPU   Iterations
-------------------------------------------------------------
-naive                   87.9 ns         87.9 ns      7922377
-append                  61.5 ns         61.5 ns     11420470
-appendWithReserve       42.1 ns         42.1 ns     16927493
-format_compile          74.2 ns         74.2 ns      9445351
-format_runtime           113 ns          113 ns      6153164
-format_to               85.5 ns         85.5 ns      8221508
-fast_io_print           22.6 ns         22.6 ns     30832719
-fast_io_concat          65.8 ns         65.8 ns     10479647
-nullop                 0.254 ns        0.254 ns   1000000000
+.. code::
+
+	cqwrteur@DESKTOP-C4VAUFM:~/format-benchmark/build/fileb$ ../file-int-benchmark-in-order
+	The number of values by digit count:
+	1     10
+	2     90
+	3    900
+	4   9000
+	5  90000
+	6 900000
+	7      0
+	8      0
+	9      0
+	10      0
+	2020-06-21T10:14:33-04:00
+	Running ../file-int-benchmark-in-order
+	Run on (12 X 3593.26 MHz CPU s)
+	CPU Caches:
+	L1 Data 32 KiB (x6)
+	L1 Instruction 32 KiB (x6)
+	L2 Unified 512 KiB (x6)
+	L3 Unified 16384 KiB (x1)
+	Load Average: 0.18, 0.17, 0.40
+	----------------------------------------------------------------
+	Benchmark                      Time             CPU   Iterations
+	----------------------------------------------------------------
+	fprintf                 57592333 ns     57592426 ns           12
+	std_ofstream            55919308 ns     55919377 ns           12
+	fmt_print               42610800 ns     42610357 ns           17
+	std_to_chars            11397534 ns     11397338 ns           62
+	fmt_to_string           16661595 ns     16661393 ns           42
+	fmt_format_runtime      35192181 ns     35191612 ns           21
+	fmt_format_compile      19402943 ns     19402683 ns           35
+	fmt_format_to_runtime   26155774 ns     26139605 ns           27
+	fmt_format_to_compile   11257168 ns     11256815 ns           59
+	fmt_format_int          11861714 ns     11861545 ns           59
+	boost_lexical_cast      29049683 ns     29049091 ns           23
+	boost_format           241224867 ns    241225457 ns            3
+	boost_karma_generate    16753700 ns     16753511 ns           42
+	voigt_itostr            18430816 ns     18430585 ns           37
+	u2985907                10755685 ns     10755565 ns           66
+	u2985907_correct         7280822 ns      7280711 ns           93
+	std_to_chars_fast        8932342 ns      8932051 ns           80
+	decimal_from            14453468 ns     14453466 ns           47
+	stout_ltoa              30093805 ns     30093804 ns           22
+	fast_io_concat          14463548 ns     14463376 ns           48
+	fast_io_concatln        13483156 ns     13473767 ns           52
+	fast_io_print_reserve   12277633 ns     12277631 ns           57
+	fast_io_println          6885923 ns      6885925 ns          106
+
+
+.. code::
+
+	cqwrteur@DESKTOP-C4VAUFM:~/format-benchmark/build$ ./concat-benchmark
+	2020-06-21T10:17:13-04:00
+	Running ./concat-benchmark
+	Run on (12 X 3593.26 MHz CPU s)
+	CPU Caches:
+	L1 Data 32 KiB (x6)
+	L1 Instruction 32 KiB (x6)
+	L2 Unified 512 KiB (x6)
+	L3 Unified 16384 KiB (x1)
+	Load Average: 0.14, 0.24, 0.40
+	------------------------------------------------------------
+	Benchmark                  Time             CPU   Iterations
+	------------------------------------------------------------
+	naive                   87.9 ns         87.9 ns      7922377
+	append                  61.5 ns         61.5 ns     11420470
+	appendWithReserve       42.1 ns         42.1 ns     16927493
+	format_compile          74.2 ns         74.2 ns      9445351
+	format_runtime           113 ns          113 ns      6153164
+	format_to               85.5 ns         85.5 ns      8221508
+	fast_io_print           22.6 ns         22.6 ns     30832719
+	fast_io_concat          65.8 ns         65.8 ns     10479647
+	nullop                 0.254 ns        0.254 ns   1000000000
 

--- a/src/concat-benchmark.cc
+++ b/src/concat-benchmark.cc
@@ -99,7 +99,7 @@ void fast_io_print(benchmark::State& state) {
   for (auto _ : state) {
     fast_io::internal_temporary_buffer<char> output;
     print(output, "Result: ",str1,": (",str2,",",str3,",",str4,",",str5,")");
-    benchmark::DoNotOptimize(output.data());
+    benchmark::DoNotOptimize(obuffer_begin(output));
   }
 }
 BENCHMARK(fast_io_print);

--- a/src/concat-benchmark.cc
+++ b/src/concat-benchmark.cc
@@ -89,6 +89,25 @@ void format_to(benchmark::State& state) {
   }
 }
 BENCHMARK(format_to);
+#ifdef __cpp_lib_concepts>=201907L
+void fast_io_print(benchmark::State& state) {
+  benchmark::ClobberMemory();
+  for (auto _ : state) {
+    fast_io::internal_temporary_buffer<char> output;
+    print(output, "Result: ",str1,": (",str2,",",str3,",",str4,","str5,")");
+    benchmark::DoNotOptimize(output.data());
+  }
+}
+BENCHMARK(fast_io_print);
+void fast_io_concat(benchmark::State& state) {
+  benchmark::ClobberMemory();
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(fast_io::concat("Result: ",str1,": (",str2,",",str3,",",str4,","str5,")").data());
+  }
+}
+BENCHMARK(fast_io_concat);
+
+#endif
 
 void nullop(benchmark::State& state) {
   for (auto _ : state) {

--- a/src/concat-benchmark.cc
+++ b/src/concat-benchmark.cc
@@ -98,7 +98,7 @@ void fast_io_print(benchmark::State& state) {
   benchmark::ClobberMemory();
   for (auto _ : state) {
     fast_io::internal_temporary_buffer<char> output;
-    print(output, "Result: ",str1,": (",str2,",",str3,",",str4,","str5,")");
+    print(output, "Result: ",str1,": (",str2,",",str3,",",str4,",",str5,")");
     benchmark::DoNotOptimize(output.data());
   }
 }
@@ -106,7 +106,7 @@ BENCHMARK(fast_io_print);
 void fast_io_concat(benchmark::State& state) {
   benchmark::ClobberMemory();
   for (auto _ : state) {
-    benchmark::DoNotOptimize(fast_io::concat("Result: ",str1,": (",str2,",",str3,",",str4,","str5,")").data());
+    benchmark::DoNotOptimize(fast_io::concat("Result: ",str1,": (",str2,",",str3,",",str4,",",str5,")").data());
   }
 }
 BENCHMARK(fast_io_concat);

--- a/src/concat-benchmark.cc
+++ b/src/concat-benchmark.cc
@@ -1,6 +1,10 @@
 #include <benchmark/benchmark.h>
 #include <fmt/compile.h>
 
+#ifdef __cpp_lib_concepts>=201907L
+#include "../fast_io/include/fast_io.h"
+#endif
+
 #include <string>
 
 std::string str1 = "label";

--- a/src/concat-benchmark.cc
+++ b/src/concat-benchmark.cc
@@ -1,7 +1,7 @@
 #include <benchmark/benchmark.h>
 #include <fmt/compile.h>
 
-#ifdef __cpp_lib_concepts>=201907L
+#if __cpp_lib_concepts>=201907L
 #include "../fast_io/include/fast_io.h"
 #endif
 
@@ -93,7 +93,7 @@ void format_to(benchmark::State& state) {
   }
 }
 BENCHMARK(format_to);
-#ifdef __cpp_lib_concepts>=201907L
+#if __cpp_lib_concepts>=201907L
 void fast_io_print(benchmark::State& state) {
   benchmark::ClobberMemory();
   for (auto _ : state) {

--- a/src/file-int-benchmark-in-order.cc
+++ b/src/file-int-benchmark-in-order.cc
@@ -1,0 +1,568 @@
+// A decimal integer to string conversion benchmark
+//
+// Copyright (c) 2019 - present, Victor Zverovich
+// All rights reserved.
+
+#include <benchmark/benchmark.h>
+#include <fmt/compile.h>
+
+#include <algorithm>
+#include <boost/format.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/spirit/include/karma.hpp>
+#include <charconv>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+#include <numeric>
+#include <random>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <fstream>
+
+#if __cpp_lib_concepts>=201907L
+#include "../fast_io/include/fast_io.h"
+#include "../fast_io/include/fast_io_device.h"
+#endif
+
+#include "itostr.cc"
+
+// The method by StackOverflow user
+// https://stackoverflow.com/users/2985907/user2985907 sometimes incorrectly
+// attributed to jiaendu: https://stackoverflow.com/a/19944488/471164
+inline int u2985907_utoa10(unsigned int value, char* str) {
+#define JOIN(N) \
+  N "0", N "1", N "2", N "3", N "4", N "5", N "6", N "7", N "8", N "9"
+
+#define JOIN2(N)                                                   \
+  JOIN(N "0"), JOIN(N "1"), JOIN(N "2"), JOIN(N "3"), JOIN(N "4"), \
+      JOIN(N "5"), JOIN(N "6"), JOIN(N "7"), JOIN(N "8"), JOIN(N "9")
+
+#define JOIN3(N)                                                        \
+  JOIN2(N "0"), JOIN2(N "1"), JOIN2(N "2"), JOIN2(N "3"), JOIN2(N "4"), \
+      JOIN2(N "5"), JOIN2(N "6"), JOIN2(N "7"), JOIN2(N "8"), JOIN2(N "9")
+
+#define JOIN4                                                             \
+  JOIN3("0"), JOIN3("1"), JOIN3("2"), JOIN3("3"), JOIN3("4"), JOIN3("5"), \
+      JOIN3("6"), JOIN3("7"), JOIN3("8"), JOIN3("9")
+
+#define JOIN5(N)                                                            \
+  JOIN(N), JOIN(N "1"), JOIN(N "2"), JOIN(N "3"), JOIN(N "4"), JOIN(N "5"), \
+      JOIN(N "6"), JOIN(N "7"), JOIN(N "8"), JOIN(N "9")
+
+#define JOIN6                                                            \
+  JOIN5(""), JOIN2("1"), JOIN2("2"), JOIN2("3"), JOIN2("4"), JOIN2("5"), \
+      JOIN2("6"), JOIN2("7"), JOIN2("8"), JOIN2("9")
+
+#define F(N) ((N) >= 100 ? 3 : (N) >= 10 ? 2 : 1)
+
+#define F10(N)                                                                \
+  F(N), F(N + 1), F(N + 2), F(N + 3), F(N + 4), F(N + 5), F(N + 6), F(N + 7), \
+      F(N + 8), F(N + 9)
+
+#define F100(N)                                                            \
+  F10(N), F10(N + 10), F10(N + 20), F10(N + 30), F10(N + 40), F10(N + 50), \
+      F10(N + 60), F10(N + 70), F10(N + 80), F10(N + 90)
+
+  static const short offsets[] = {F100(0),   F100(100), F100(200), F100(300),
+                                  F100(400), F100(500), F100(600), F100(700),
+                                  F100(800), F100(900)};
+
+  static const char table1[][4] = {JOIN("")};
+  static const char table2[][4] = {JOIN2("")};
+  static const char table3[][4] = {JOIN3("")};
+  static const char table4[][8] = {JOIN4};
+  static const char table5[][4] = {JOIN6};
+
+#undef JOIN
+#undef JOIN2
+#undef JOIN3
+#undef JOIN4
+#undef F
+#undef F10
+#undef F100
+
+  char* wstr;
+#if (_WIN64 || __x86_64__ || __ppc64__)
+  uint64_t remains[2];
+#else
+  uint32_t remains[2];
+#endif
+  unsigned int v2;
+
+  if (value >= 100000000) {
+#if (_WIN64 || __x86_64__ || __ppc64__)
+    remains[0] = (((uint64_t)value * (uint64_t)3518437209) >> 45);
+    remains[1] = (((uint64_t)value * (uint64_t)2882303762) >> 58);
+#else
+    remains[0] = value / 10000;
+    remains[1] = value / 100000000;
+#endif
+    v2 = remains[1];
+    remains[1] = remains[0] - remains[1] * 10000;
+    remains[0] = value - remains[0] * 10000;
+    if (v2 >= 10) {
+      memcpy(str, table5[v2], 2);
+      str += 2;
+      memcpy(str, table4[remains[1]], 4);
+      str += 4;
+      memcpy(str, table4[remains[0]], 4);
+      return 10;
+    } else {
+      *(char*)str = v2 + '0';
+      str += 1;
+      memcpy(str, table4[remains[1]], 4);
+      str += 4;
+      memcpy(str, table4[remains[0]], 4);
+      return 9;
+    }
+  } else if (value >= 10000) {
+#if (_WIN64 || __x86_64__ || __ppc64__)
+    v2 = (((uint64_t)value * (uint64_t)3518437209) >> 45);
+#else
+    v2 = value / 10000;
+#endif
+    remains[0] = value - v2 * 10000;
+    if (v2 >= 1000) {
+      memcpy(str, table4[v2], 4);
+      str += 4;
+      memcpy(str, table4[remains[0]], 4);
+      return 8;
+    } else {
+      wstr = str;
+      memcpy(wstr, table5[v2], 4);
+      wstr += offsets[v2];
+      memcpy(wstr, table4[remains[0]], 4);
+      wstr += 4;
+      return (wstr - str);
+    }
+  } else {
+    if (value >= 1000) {
+      memcpy(str, table4[value], 4);
+      return 4;
+    } else if (value >= 100) {
+      memcpy(str, table3[value], 3);
+      return 3;
+    } else if (value >= 10) {
+      memcpy(str, table2[value], 2);
+      return 2;
+    } else {
+      *(char*)str = *(char*)table1[value];
+      return 1;
+    }
+  }
+}
+
+int u2985907_itoa10(int value, char* str) {
+  if (value < 0) { *(str++) = '-'; 
+    return u2985907_utoa10(-value, str) + 1; 
+  }
+  else return u2985907_utoa10(value, str);
+}
+
+// Integer to string converter by Alf P. Steinbach modified to return a pointer
+// past the end of the output to avoid calling strlen.
+namespace cppx {
+inline auto unsigned_to_decimal(unsigned long number, char* buffer) {
+  if (number == 0) {
+    *buffer++ = '0';
+  } else {
+    char* p_first = buffer;
+    while (number != 0) {
+      *buffer++ = '0' + number % 10;
+      number /= 10;
+    }
+    std::reverse(p_first, buffer);
+  }
+  *buffer = '\0';
+  return buffer;
+}
+
+inline auto to_decimal(long number, char* buffer) {
+  if (number < 0) {
+    buffer[0] = '-';
+    return unsigned_to_decimal(-number, buffer + 1);
+  } else {
+    return unsigned_to_decimal(number, buffer);
+  }
+}
+
+inline auto decimal_from(long number, char* buffer) {
+  return to_decimal(number, buffer);
+}
+}  // namespace cppx
+
+// Public domain ltoa by Robert B. Stout dba MicroFirm.
+char* ltoa(long N, char* str, int base) {
+  int i = 2;
+  long uarg;
+  constexpr auto BUFSIZE = (sizeof(long) * 8 + 1);
+  char *tail, *head = str, buf[BUFSIZE];
+
+  if (36 < base || 2 > base) base = 10; /* can only use 0-9, A-Z        */
+  tail = &buf[BUFSIZE - 1];             /* last character position      */
+  *tail-- = '\0';
+
+  if (10 == base && N < 0L) {
+    *head++ = '-';
+    uarg = -N;
+  } else
+    uarg = N;
+
+  if (uarg) {
+    for (i = 1; uarg; ++i) {
+      ldiv_t r;
+
+      r = ldiv(uarg, base);
+      *tail-- = (char)(r.rem + ((9L < r.rem) ? ('A' - 10L) : '0'));
+      uarg = r.quot;
+    }
+  } else
+    *tail-- = '0';
+
+  memcpy(head, ++tail, i);
+  return str;
+}
+
+// Computes a digest of data. It is used both to prevent compiler from
+// optimizing away the benchmarked code and to verify that the results are
+// correct. The overhead is less than 2.5% compared to just DoNotOptimize.
+FMT_INLINE unsigned compute_digest(fmt::string_view data) {
+  unsigned digest = 0;
+  for (char c : data) digest += c;
+  return digest;
+}
+
+struct Data {
+  std::vector<int> values;
+  unsigned digest;
+
+  auto begin() const { return values.begin(); }
+  auto end() const { return values.end(); }
+
+  // Prints the number of values by digit count, e.g.
+  //  1  27263
+  //  2 247132
+  //  3 450601
+  //  4 246986
+  //  5  25188
+  //  6   2537
+  //  7    251
+  //  8     39
+  //  9      2
+  // 10      1
+  void print_digit_counts() const {
+    int counts[11] = {};
+    for (auto value : values) ++counts[fmt::format_int(value).size()];
+    fmt::print("The number of values by digit count:\n");
+    for (int i = 1; i < 11; ++i) fmt::print("{:2} {:6}\n", i, counts[i]);
+  }
+
+  Data() : values(1'000'000) {
+    // Similar data as in Boost Karma int generator test:
+    // https://www.boost.org/doc/libs/1_63_0/libs/spirit/workbench/karma/int_generator.cpp
+    // with rand replaced by uniform_int_distribution for consistent results
+    // across platforms.
+    for(int i{};i!=values.size();++i)
+      values[i]=i;
+    digest =
+        std::accumulate(begin(), end(), unsigned(), [](unsigned lhs, int rhs) {
+          char buffer[12];
+          unsigned size = std::sprintf(buffer, "%d", rhs);
+          return lhs + compute_digest({buffer, size});
+        });
+    print_digit_counts();
+  }
+} data;
+
+void fprintf(benchmark::State& state) {
+  std::unique_ptr<FILE,decltype(std::fclose)*> fp(std::fopen("fprintf.txt","wb"),std::fclose);
+  for (auto s : state) {
+    for (auto value : data) {
+      std::fprintf(fp.get(), "%d\n", value);
+    }
+  }
+}
+BENCHMARK(fprintf);
+
+void std_ofstream(benchmark::State& state) {
+  std::ofstream os("ofstream.txt",std::ofstream::binary);
+  for (auto s : state) {
+    for (auto value : data) {
+      os << value <<'\n';
+    }
+  }
+}
+BENCHMARK(std_ofstream);
+
+void fmt_print(benchmark::State& state) {
+  std::unique_ptr<FILE,decltype(std::fclose)*> fp(std::fopen("fmt_print.txt","wb"),std::fclose);
+  for (auto s : state) {
+    for (auto value : data) {
+      fmt::print(fp.get(),"{}\n", value);
+    }
+  }
+}
+BENCHMARK(fmt_print);
+
+
+#if __cpp_lib_concepts>=201907L
+
+void std_to_chars(benchmark::State& state) {
+  fast_io::obuf_file obf("std_to_chars.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[13];
+      auto res = std::to_chars(buffer, buffer + sizeof(buffer), value);
+      *res.ptr=u8'\n';
+      write(obf,buffer,++res.ptr);
+    }
+  }
+}
+BENCHMARK(std_to_chars);
+
+void fmt_to_string(benchmark::State& state) {
+  fast_io::obuf_file obf("fmt_to_string.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      print(obf,fmt::to_string(value));
+    }
+  }
+}
+BENCHMARK(fmt_to_string);
+
+void fmt_format_runtime(benchmark::State& state) {
+  fast_io::obuf_file obf("fmt_format_runtime.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      print(obf,fmt::format("{}\n", value));
+    }
+  }
+}
+BENCHMARK(fmt_format_runtime);
+
+void fmt_format_compile(benchmark::State& state) {
+  fast_io::obuf_file obf("fmt_format_runtime.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      print(obf,fmt::format(FMT_COMPILE("{}\n"), value));
+    }
+  }
+}
+BENCHMARK(fmt_format_compile);
+
+void fmt_format_to_runtime(benchmark::State& state) {
+  fast_io::obuf_file obf("fmt_format_to_runtime.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[13];
+      auto end = fmt::format_to(buffer, "{}\n", value);
+      write(obf,buffer,end);
+    }
+  }
+}
+BENCHMARK(fmt_format_to_runtime);
+
+void fmt_format_to_compile(benchmark::State& state) {
+  fast_io::obuf_file obf("fmt_format_to_compile.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[13];
+      constexpr auto f = fmt::compile<int>(FMT_STRING("{}"));
+      auto end = fmt::format_to(buffer, f, value);
+      *end=u8'\n';
+      write(obf,buffer,++end);
+    }
+  }
+}
+BENCHMARK(fmt_format_to_compile);
+
+void fmt_format_int(benchmark::State& state) {
+  fast_io::obuf_file obf("fmt_format_int.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      auto f = fmt::format_int(value);
+      write(obf,f.data(),f.data()+f.size());
+      put(obf,u8'\n');
+    }
+  }
+}
+BENCHMARK(fmt_format_int);
+
+void boost_lexical_cast(benchmark::State& state) {
+  fast_io::obuf_file obf("boost_lexical_cast.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      println(obf,boost::lexical_cast<std::string>(value));
+    }
+  }
+}
+BENCHMARK(boost_lexical_cast);
+
+void boost_format(benchmark::State& state) {
+  fast_io::obuf_file obf("boost_format.txt");
+  boost::format fmt("%d\n");
+  for (auto s : state) {
+    for (auto value : data) {
+      print(obf,boost::str(fmt % value));
+    }
+  }
+}
+BENCHMARK(boost_format);
+
+void boost_karma_generate(benchmark::State& state) {
+  fast_io::obuf_file obf("boost_karma_generate.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[13];
+      char* ptr = buffer;
+      boost::spirit::karma::generate(ptr, boost::spirit::karma::int_, value);
+      *ptr=u8'\n';
+      write(obf,buffer,++ptr);
+    }
+  }
+}
+BENCHMARK(boost_karma_generate);
+
+void voigt_itostr(benchmark::State& state) {
+  fast_io::obuf_file obf("voigt_itostr.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      println(obf,itostr(value));
+    }
+  }
+}
+BENCHMARK(voigt_itostr);
+
+
+//THIS IS NOT THE CORRECT WAY FOR USING jiaendu
+void u2985907(benchmark::State& state) {
+  fast_io::obuf_file obf("u2985907_itoa10.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[13];
+      unsigned size = u2985907_itoa10(value, buffer);
+      buffer[size]=u8'\n';
+      write(obf,buffer,buffer+(++size));
+    }
+  }
+}
+BENCHMARK(u2985907);
+
+void u2985907_correct(benchmark::State& state) {
+  fast_io::obuf_file obf("u2985907_itoa10_correct.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      auto ptr=oreserve(obf,13);
+      if(ptr)[[likely]]
+      {
+        unsigned size = u2985907_itoa10(value, ptr);
+        ptr[size]=u8'\n';
+        orelease(obf,ptr+(++size));
+      }
+      else
+      {
+        char buffer[13];
+        unsigned size = u2985907_itoa10(value, buffer);
+        buffer[size]=u8'\n';
+        write(obf,buffer,buffer+(++size));
+      }
+    }
+  }
+}
+BENCHMARK(u2985907_correct);
+
+void std_to_chars_fast(benchmark::State& state) {
+  fast_io::obuf_file obf("std_to_chars_fast.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      auto ptr=oreserve(obf,13);
+      if(ptr)[[likely]]
+      {
+        auto res = std::to_chars(ptr, ptr + 13, value);
+        *res.ptr=u8'\n';
+        orelease(obf,res.ptr+1);
+      }
+      else
+      {
+        char buffer[13];
+        auto res = std::to_chars(buffer, buffer + sizeof(buffer), value);
+        *res.ptr=u8'\n';
+        write(obf,buffer,res.ptr+1);
+      }
+    }
+  }
+}
+BENCHMARK(std_to_chars_fast);
+
+void decimal_from(benchmark::State& state) {
+  fast_io::obuf_file obf("decimal_from.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[13];
+      auto end = cppx::decimal_from(value, buffer);
+      *end=u8'\n';
+      write(obf,buffer,++end);
+    }
+  }
+}
+BENCHMARK(decimal_from);
+
+void stout_ltoa(benchmark::State& state) {
+  fast_io::obuf_file obf("stout_ltoa.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[12];
+      ltoa(value, buffer, 12);
+      println(obf,fast_io::chvw(buffer));
+      // ltoa doesn't give the size so this invokes strlen.
+    }
+  }
+}
+BENCHMARK(stout_ltoa);
+
+void fast_io_concat(benchmark::State& state) {
+  fast_io::obuf_file obf("fast_io_concat.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      println(obf,fast_io::concat(value));
+    }
+  }
+}
+BENCHMARK(fast_io_concat);
+
+void fast_io_concatln(benchmark::State& state) {
+  fast_io::obuf_file obf("fast_io_concatln.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      print(obf,fast_io::concatln(value));
+    }
+  }
+}
+BENCHMARK(fast_io_concatln);
+
+void fast_io_print_reserve(benchmark::State& state) {
+  fast_io::obuf_file obf("fast_io_print_reserve.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      auto rsv(fast_io::print_reserve(value));
+      write(obf,rsv.data(),rsv.data()+rsv.size());
+      put(obf,u8'\n');
+    }
+  }
+}
+BENCHMARK(fast_io_print_reserve);
+
+void fast_io_println(benchmark::State& state) {
+  fast_io::obuf_file obf("fast_io_println.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      println(obf,value);
+    }
+  }
+}
+BENCHMARK(fast_io_println);
+#endif
+
+BENCHMARK_MAIN();

--- a/src/file-int-benchmark.cc
+++ b/src/file-int-benchmark.cc
@@ -1,0 +1,521 @@
+// A decimal integer to string conversion benchmark
+//
+// Copyright (c) 2019 - present, Victor Zverovich
+// All rights reserved.
+
+#include <benchmark/benchmark.h>
+#include <fmt/compile.h>
+
+#include <algorithm>
+#include <boost/format.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/spirit/include/karma.hpp>
+#include <charconv>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+#include <numeric>
+#include <random>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#if __cpp_lib_concepts>=201907L
+#include "../fast_io/include/fast_io.h"
+#include "../fast_io/include/fast_io_device.h"
+#endif
+
+#include "itostr.cc"
+
+// The method by StackOverflow user
+// https://stackoverflow.com/users/2985907/user2985907 sometimes incorrectly
+// attributed to jiaendu: https://stackoverflow.com/a/19944488/471164
+inline int u2985907_utoa10(unsigned int value, char* str) {
+#define JOIN(N) \
+  N "0", N "1", N "2", N "3", N "4", N "5", N "6", N "7", N "8", N "9"
+
+#define JOIN2(N)                                                   \
+  JOIN(N "0"), JOIN(N "1"), JOIN(N "2"), JOIN(N "3"), JOIN(N "4"), \
+      JOIN(N "5"), JOIN(N "6"), JOIN(N "7"), JOIN(N "8"), JOIN(N "9")
+
+#define JOIN3(N)                                                        \
+  JOIN2(N "0"), JOIN2(N "1"), JOIN2(N "2"), JOIN2(N "3"), JOIN2(N "4"), \
+      JOIN2(N "5"), JOIN2(N "6"), JOIN2(N "7"), JOIN2(N "8"), JOIN2(N "9")
+
+#define JOIN4                                                             \
+  JOIN3("0"), JOIN3("1"), JOIN3("2"), JOIN3("3"), JOIN3("4"), JOIN3("5"), \
+      JOIN3("6"), JOIN3("7"), JOIN3("8"), JOIN3("9")
+
+#define JOIN5(N)                                                            \
+  JOIN(N), JOIN(N "1"), JOIN(N "2"), JOIN(N "3"), JOIN(N "4"), JOIN(N "5"), \
+      JOIN(N "6"), JOIN(N "7"), JOIN(N "8"), JOIN(N "9")
+
+#define JOIN6                                                            \
+  JOIN5(""), JOIN2("1"), JOIN2("2"), JOIN2("3"), JOIN2("4"), JOIN2("5"), \
+      JOIN2("6"), JOIN2("7"), JOIN2("8"), JOIN2("9")
+
+#define F(N) ((N) >= 100 ? 3 : (N) >= 10 ? 2 : 1)
+
+#define F10(N)                                                                \
+  F(N), F(N + 1), F(N + 2), F(N + 3), F(N + 4), F(N + 5), F(N + 6), F(N + 7), \
+      F(N + 8), F(N + 9)
+
+#define F100(N)                                                            \
+  F10(N), F10(N + 10), F10(N + 20), F10(N + 30), F10(N + 40), F10(N + 50), \
+      F10(N + 60), F10(N + 70), F10(N + 80), F10(N + 90)
+
+  static const short offsets[] = {F100(0),   F100(100), F100(200), F100(300),
+                                  F100(400), F100(500), F100(600), F100(700),
+                                  F100(800), F100(900)};
+
+  static const char table1[][4] = {JOIN("")};
+  static const char table2[][4] = {JOIN2("")};
+  static const char table3[][4] = {JOIN3("")};
+  static const char table4[][8] = {JOIN4};
+  static const char table5[][4] = {JOIN6};
+
+#undef JOIN
+#undef JOIN2
+#undef JOIN3
+#undef JOIN4
+#undef F
+#undef F10
+#undef F100
+
+  char* wstr;
+#if (_WIN64 || __x86_64__ || __ppc64__)
+  uint64_t remains[2];
+#else
+  uint32_t remains[2];
+#endif
+  unsigned int v2;
+
+  if (value >= 100000000) {
+#if (_WIN64 || __x86_64__ || __ppc64__)
+    remains[0] = (((uint64_t)value * (uint64_t)3518437209) >> 45);
+    remains[1] = (((uint64_t)value * (uint64_t)2882303762) >> 58);
+#else
+    remains[0] = value / 10000;
+    remains[1] = value / 100000000;
+#endif
+    v2 = remains[1];
+    remains[1] = remains[0] - remains[1] * 10000;
+    remains[0] = value - remains[0] * 10000;
+    if (v2 >= 10) {
+      memcpy(str, table5[v2], 2);
+      str += 2;
+      memcpy(str, table4[remains[1]], 4);
+      str += 4;
+      memcpy(str, table4[remains[0]], 4);
+      return 10;
+    } else {
+      *(char*)str = v2 + '0';
+      str += 1;
+      memcpy(str, table4[remains[1]], 4);
+      str += 4;
+      memcpy(str, table4[remains[0]], 4);
+      return 9;
+    }
+  } else if (value >= 10000) {
+#if (_WIN64 || __x86_64__ || __ppc64__)
+    v2 = (((uint64_t)value * (uint64_t)3518437209) >> 45);
+#else
+    v2 = value / 10000;
+#endif
+    remains[0] = value - v2 * 10000;
+    if (v2 >= 1000) {
+      memcpy(str, table4[v2], 4);
+      str += 4;
+      memcpy(str, table4[remains[0]], 4);
+      return 8;
+    } else {
+      wstr = str;
+      memcpy(wstr, table5[v2], 4);
+      wstr += offsets[v2];
+      memcpy(wstr, table4[remains[0]], 4);
+      wstr += 4;
+      return (wstr - str);
+    }
+  } else {
+    if (value >= 1000) {
+      memcpy(str, table4[value], 4);
+      return 4;
+    } else if (value >= 100) {
+      memcpy(str, table3[value], 3);
+      return 3;
+    } else if (value >= 10) {
+      memcpy(str, table2[value], 2);
+      return 2;
+    } else {
+      *(char*)str = *(char*)table1[value];
+      return 1;
+    }
+  }
+}
+
+int u2985907_itoa10(int value, char* str) {
+  if (value < 0) { *(str++) = '-'; 
+    return u2985907_utoa10(-value, str) + 1; 
+  }
+  else return u2985907_utoa10(value, str);
+}
+
+// Integer to string converter by Alf P. Steinbach modified to return a pointer
+// past the end of the output to avoid calling strlen.
+namespace cppx {
+inline auto unsigned_to_decimal(unsigned long number, char* buffer) {
+  if (number == 0) {
+    *buffer++ = '0';
+  } else {
+    char* p_first = buffer;
+    while (number != 0) {
+      *buffer++ = '0' + number % 10;
+      number /= 10;
+    }
+    std::reverse(p_first, buffer);
+  }
+  *buffer = '\0';
+  return buffer;
+}
+
+inline auto to_decimal(long number, char* buffer) {
+  if (number < 0) {
+    buffer[0] = '-';
+    return unsigned_to_decimal(-number, buffer + 1);
+  } else {
+    return unsigned_to_decimal(number, buffer);
+  }
+}
+
+inline auto decimal_from(long number, char* buffer) {
+  return to_decimal(number, buffer);
+}
+}  // namespace cppx
+
+// Public domain ltoa by Robert B. Stout dba MicroFirm.
+char* ltoa(long N, char* str, int base) {
+  int i = 2;
+  long uarg;
+  constexpr auto BUFSIZE = (sizeof(long) * 8 + 1);
+  char *tail, *head = str, buf[BUFSIZE];
+
+  if (36 < base || 2 > base) base = 10; /* can only use 0-9, A-Z        */
+  tail = &buf[BUFSIZE - 1];             /* last character position      */
+  *tail-- = '\0';
+
+  if (10 == base && N < 0L) {
+    *head++ = '-';
+    uarg = -N;
+  } else
+    uarg = N;
+
+  if (uarg) {
+    for (i = 1; uarg; ++i) {
+      ldiv_t r;
+
+      r = ldiv(uarg, base);
+      *tail-- = (char)(r.rem + ((9L < r.rem) ? ('A' - 10L) : '0'));
+      uarg = r.quot;
+    }
+  } else
+    *tail-- = '0';
+
+  memcpy(head, ++tail, i);
+  return str;
+}
+
+// Computes a digest of data. It is used both to prevent compiler from
+// optimizing away the benchmarked code and to verify that the results are
+// correct. The overhead is less than 2.5% compared to just DoNotOptimize.
+FMT_INLINE unsigned compute_digest(fmt::string_view data) {
+  unsigned digest = 0;
+  for (char c : data) digest += c;
+  return digest;
+}
+
+struct Data {
+  std::vector<int> values;
+  unsigned digest;
+
+  auto begin() const { return values.begin(); }
+  auto end() const { return values.end(); }
+
+  // Prints the number of values by digit count, e.g.
+  //  1  27263
+  //  2 247132
+  //  3 450601
+  //  4 246986
+  //  5  25188
+  //  6   2537
+  //  7    251
+  //  8     39
+  //  9      2
+  // 10      1
+  void print_digit_counts() const {
+    int counts[11] = {};
+    for (auto value : values) ++counts[fmt::format_int(value).size()];
+    fmt::print("The number of values by digit count:\n");
+    for (int i = 1; i < 11; ++i) fmt::print("{:2} {:6}\n", i, counts[i]);
+  }
+
+  Data() : values(1'000'000) {
+    // Similar data as in Boost Karma int generator test:
+    // https://www.boost.org/doc/libs/1_63_0/libs/spirit/workbench/karma/int_generator.cpp
+    // with rand replaced by uniform_int_distribution for consistent results
+    // across platforms.
+    std::mt19937 gen;
+    std::uniform_int_distribution<unsigned> dist(
+        0, (std::numeric_limits<int>::max)());
+    std::generate(values.begin(), values.end(), [&]() {
+      int scale = dist(gen) / 100 + 1;
+      return static_cast<int>(dist(gen) * dist(gen)) / scale;
+    });
+    digest =
+        std::accumulate(begin(), end(), unsigned(), [](unsigned lhs, int rhs) {
+          char buffer[12];
+          unsigned size = std::sprintf(buffer, "%d", rhs);
+          return lhs + compute_digest({buffer, size});
+        });
+    print_digit_counts();
+  }
+} data;
+
+void fprintf(benchmark::State& state) {
+  std::unique_ptr<FILE,decltype(fclose)*> fp(std::fopen("fprintf.txt","wb"));
+  for (auto s : state) {
+    for (auto value : data) {
+      std::fprintf(fp.get(), "%d\n", value);
+    }
+  }
+}
+BENCHMARK(sprintf);
+
+void std_ofstream(benchmark::State& state) {
+  std::ofstream os("ofstream.txt",std::ofstream::binary);
+  for (auto s : state) {
+    for (auto value : data) {
+      os << value <<'\n';
+    }
+  }
+}
+BENCHMARK(std_ofstream);
+
+void fmt_print(benchmark::State& state) {
+  std::ofstream os("fmt_print.txt",std::ofstream::binary);
+  for (auto s : state) {
+    for (auto value : data) {
+      fmt::print(os,"{}\n", value);
+    }
+  }
+}
+BENCHMARK(fmt_print);
+
+
+#if __cpp_lib_concepts>=201907L
+
+void std_to_chars(benchmark::State& state) {
+  fast_io::obuf_file obf("std_to_chars.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[13];
+      auto res = std::to_chars(buffer, buffer + sizeof(buffer), value);
+      *res.ptr=u8'\n';
+      write(obf,buffer,++res.ptr);
+    }
+  }
+}
+BENCHMARK(std_to_chars);
+
+void fmt_to_string(benchmark::State& state) {
+  fast_io::obuf_file obf("fmt_to_string.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      print(obf,fmt::to_string(value));
+    }
+  }
+}
+BENCHMARK(fmt_to_string);
+
+void fmt_format_runtime(benchmark::State& state) {
+  fast_io::obuf_file obf("fmt_format_runtime.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      print(obf,fmt::format("{}\n", value));
+    }
+  }
+}
+BENCHMARK(fmt_format_runtime);
+
+void fmt_format_compile(benchmark::State& state) {
+  fast_io::obuf_file obf("fmt_format_runtime.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      print(obf,fmt::format(FMT_COMPILE("{}\n"), value));
+    }
+  }
+}
+BENCHMARK(fmt_format_compile);
+
+void fmt_format_to_runtime(benchmark::State& state) {
+  fast_io::obuf_file obf("fmt_format_to_runtime.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[13];
+      auto end = fmt::format_to(buffer, "{}\n", value);
+      write(obf,buffer,end);
+    }
+  }
+}
+BENCHMARK(fmt_format_to_runtime);
+
+void fmt_format_to_compile(benchmark::State& state) {
+  fast_io::obuf_file obf("fmt_format_to_compile.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[13];
+      constexpr auto f = fmt::compile<int>(FMT_STRING("{}"));
+      auto end = fmt::format_to(buffer, f, value);
+      *end=u8'\n';
+      write(obf,buffer,++end);
+    }
+  }
+}
+BENCHMARK(fmt_format_to_compile);
+
+void fmt_format_int(benchmark::State& state) {
+  fast_io::obuf_file obf("fmt_format_int.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      auto f = fmt::format_int(value);
+      write(obf,f.data(),f.data()+f.size());
+      put(obf,u8'\n');
+    }
+  }
+}
+BENCHMARK(fmt_format_int);
+
+void boost_lexical_cast(benchmark::State& state) {
+  fast_io::obuf_file obf("boost_lexical_cast.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      println(obf,boost::lexical_cast<std::string>(value));
+    }
+  }
+}
+BENCHMARK(boost_lexical_cast);
+
+void boost_format(benchmark::State& state) {
+  fast_io::obuf_file obf("boost_format.txt");
+  boost::format fmt("%d\n");
+  for (auto s : state) {
+    for (auto value : data) {
+      print(obf,boost::str(fmt % value));
+    }
+  }
+}
+BENCHMARK(boost_format);
+
+void boost_karma_generate(benchmark::State& state) {
+  fast_io::obuf_file obf("boost_karma_generate.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[13];
+      char* ptr = buffer;
+      boost::spirit::karma::generate(ptr, boost::spirit::karma::int_, value);
+      *ptr=u8'\n';
+      write(obf,buffer,++ptr);
+    }
+  }
+}
+BENCHMARK(boost_karma_generate);
+
+void voigt_itostr(benchmark::State& state) {
+  fast_io::obuf_file obf("voigt_itostr.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      println(obf,itostr(value));
+    }
+  }
+}
+BENCHMARK(voigt_itostr);
+
+void u2985907(benchmark::State& state) {
+  fast_io::obuf_file obf("u2985907_itoa10.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[13];
+      unsigned size = u2985907_itoa10(value, buffer);
+      println(obf,buffer,buffer+size)
+    }
+  }
+}
+BENCHMARK(u2985907);
+
+void decimal_from(benchmark::State& state) {
+  fast_io::obuf_file obf("decimal_from.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[13];
+      auto end = cppx::decimal_from(value, buffer);
+      *end=u8'\n';
+      write(obf,buffer,++end);
+    }
+  }
+}
+BENCHMARK(decimal_from);
+
+void stout_ltoa(benchmark::State& state) {
+  fast_io::obuf_file obf("stout_ltoa.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[13];
+      ltoa(value, buffer, 13);
+      print(obf,fast_io::chvw(buffer));
+      // ltoa doesn't give the size so this invokes strlen.
+    }
+  }
+}
+BENCHMARK(stout_ltoa);
+
+void fast_io_concat(benchmark::State& state) {
+  fast_io::obuf_file obf("fast_io_concatln.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      println(obf,fast_io::concat(value));
+    }
+  }
+}
+BENCHMARK(fast_io_concatln);
+
+void fast_io_concatln(benchmark::State& state) {
+  fast_io::obuf_file obf("fast_io_concatln.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      print(obf,fast_io::concatln(value));
+    }
+  }
+}
+BENCHMARK(fast_io_concatln);
+void fast_io_print_reserve(benchmark::State& state) {
+  fast_io::obuf_file obf("fast_io_print_reserve.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      auto rsv(fast_io::print_reserve(value));
+      println(obf,rsv);
+    }
+  }
+}
+BENCHMARK(fast_io_print_reserve);
+
+void fast_io_println(benchmark::State& state) {
+  fast_io::obuf_file obf("fast_io_println.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      println(obf,rsv);
+    }
+  }
+}
+BENCHMARK(fast_io_println);
+#endif
+
+BENCHMARK_MAIN();

--- a/src/file-int-benchmark.cc
+++ b/src/file-int-benchmark.cc
@@ -485,7 +485,7 @@ void std_to_chars_fast(benchmark::State& state) {
       auto ptr=oreserve(obf,13);
       if(ptr)[[likely]]
       {
-        auto res = std::to_chars(buffer, buffer + 13, value);
+        auto res = std::to_chars(ptr, ptr + 13, value);
         *res.ptr=u8'\n';
         orelease(obf,res.ptr+1);
       }

--- a/src/file-int-benchmark.cc
+++ b/src/file-int-benchmark.cc
@@ -497,16 +497,6 @@ void fast_io_concatln(benchmark::State& state) {
   }
 }
 BENCHMARK(fast_io_concatln);
-void fast_io_print_reserve(benchmark::State& state) {
-  fast_io::obuf_file obf("fast_io_print_reserve.txt");
-  for (auto s : state) {
-    for (auto value : data) {
-      auto rsv(fast_io::print_reserve(value));
-      println(obf,rsv);
-    }
-  }
-}
-BENCHMARK(fast_io_print_reserve);
 
 void fast_io_println(benchmark::State& state) {
   fast_io::obuf_file obf("fast_io_println.txt");

--- a/src/file-int-benchmark.cc
+++ b/src/file-int-benchmark.cc
@@ -552,7 +552,7 @@ void fast_io_print_reserve(benchmark::State& state) {
   for (auto s : state) {
     for (auto value : data) {
       auto rsv(fast_io::print_reserve(value));
-      print(obf,rsv.data(),rsv.data()+rsv.size());
+      write(obf,rsv.data(),rsv.data()+rsv.size());
       put(obf,u8'\n');
     }
   }

--- a/src/file-int-benchmark.cc
+++ b/src/file-int-benchmark.cc
@@ -281,14 +281,14 @@ struct Data {
 } data;
 
 void fprintf(benchmark::State& state) {
-  std::unique_ptr<FILE,decltype(fclose)*> fp(std::fopen("fprintf.txt","wb"));
+  std::unique_ptr<FILE,decltype(std::fclose)*> fp(std::fopen("fprintf.txt","wb"),std::fclose);
   for (auto s : state) {
     for (auto value : data) {
       std::fprintf(fp.get(), "%d\n", value);
     }
   }
 }
-BENCHMARK(sprintf);
+BENCHMARK(fprintf);
 
 void std_ofstream(benchmark::State& state) {
   std::ofstream os("ofstream.txt",std::ofstream::binary);

--- a/src/file-int-benchmark.cc
+++ b/src/file-int-benchmark.cc
@@ -19,6 +19,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <fstream>
 
 #if __cpp_lib_concepts>=201907L
 #include "../fast_io/include/fast_io.h"
@@ -445,7 +446,7 @@ void u2985907(benchmark::State& state) {
     for (auto value : data) {
       char buffer[13];
       unsigned size = u2985907_itoa10(value, buffer);
-      println(obf,buffer,buffer+size)
+      println(obf,buffer,buffer+size);
     }
   }
 }
@@ -478,14 +479,14 @@ void stout_ltoa(benchmark::State& state) {
 BENCHMARK(stout_ltoa);
 
 void fast_io_concat(benchmark::State& state) {
-  fast_io::obuf_file obf("fast_io_concatln.txt");
+  fast_io::obuf_file obf("fast_io_concat.txt");
   for (auto s : state) {
     for (auto value : data) {
       println(obf,fast_io::concat(value));
     }
   }
 }
-BENCHMARK(fast_io_concatln);
+BENCHMARK(fast_io_concat);
 
 void fast_io_concatln(benchmark::State& state) {
   fast_io::obuf_file obf("fast_io_concatln.txt");

--- a/src/file-int-benchmark.cc
+++ b/src/file-int-benchmark.cc
@@ -440,6 +440,8 @@ void voigt_itostr(benchmark::State& state) {
 }
 BENCHMARK(voigt_itostr);
 
+
+//THIS IS NOT THE CORRECT WAY FOR USING jiaendu
 void u2985907(benchmark::State& state) {
   fast_io::obuf_file obf("u2985907_itoa10.txt");
   for (auto s : state) {
@@ -452,6 +454,52 @@ void u2985907(benchmark::State& state) {
   }
 }
 BENCHMARK(u2985907);
+
+void u2985907_correct(benchmark::State& state) {
+  fast_io::obuf_file obf("u2985907_itoa10_correct.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      auto ptr=oreserve(obf,13);
+      if(ptr)[[likely]]
+      {
+        unsigned size = u2985907_itoa10(value, buffer);
+        ptr[size]=u8'\n';
+        orelease(obf,ptr+(++size));
+      }
+      else
+      {
+        char buffer[13];
+        unsigned size = u2985907_itoa10(value, buffer);
+        buffer[size]=u8'\n';
+        write(obf,buffer,buffer+(++size));
+      }
+    }
+  }
+}
+BENCHMARK(u2985907_correct);
+
+void std_to_chars_fast(benchmark::State& state) {
+  fast_io::obuf_file obf("std_to_chars_fast.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      auto ptr=oreserve(obf,13);
+      if(ptr)[[likely]]
+      {
+        unsigned size = std::to_chars(ptr,ptr+13,value);
+        ptr[size]=u8'\n';
+        orelease(obf,ptr+(++size));
+      }
+      else
+      {
+        char buffer[13];
+        unsigned size = std::to_chars(ptr,ptr+13,value);
+        buffer[size]=u8'\n';
+        write(obf,buffer,buffer+(++size));
+      }
+    }
+  }
+}
+BENCHMARK(std_to_chars_fast);
 
 void decimal_from(benchmark::State& state) {
   fast_io::obuf_file obf("decimal_from.txt");
@@ -498,6 +546,18 @@ void fast_io_concatln(benchmark::State& state) {
   }
 }
 BENCHMARK(fast_io_concatln);
+
+void fast_io_print_reserve(benchmark::State& state) {
+  fast_io::obuf_file obf("fast_io_print_reserve.txt");
+  for (auto s : state) {
+    for (auto value : data) {
+      auto rsv(fast_io::print_reserve(value));
+      print(obf,rsv.data(),rsv.data()+rsv.size());
+      put(obf,u8'\n');
+    }
+  }
+}
+BENCHMARK(fast_io_print_reserve);
 
 void fast_io_println(benchmark::State& state) {
   fast_io::obuf_file obf("fast_io_println.txt");

--- a/src/file-int-benchmark.cc
+++ b/src/file-int-benchmark.cc
@@ -302,10 +302,10 @@ void std_ofstream(benchmark::State& state) {
 BENCHMARK(std_ofstream);
 
 void fmt_print(benchmark::State& state) {
-  std::ofstream os("fmt_print.txt",std::ofstream::binary);
+  std::unique_ptr<FILE,decltype(std::fclose)*> fp(std::fopen("fmt_print.txt","wb"),std::fclose);
   for (auto s : state) {
     for (auto value : data) {
-      fmt::print(os,"{}\n", value);
+      fmt::print(fp.get(),"{}\n", value);
     }
   }
 }

--- a/src/file-int-benchmark.cc
+++ b/src/file-int-benchmark.cc
@@ -462,7 +462,7 @@ void u2985907_correct(benchmark::State& state) {
       auto ptr=oreserve(obf,13);
       if(ptr)[[likely]]
       {
-        unsigned size = u2985907_itoa10(value, buffer);
+        unsigned size = u2985907_itoa10(value, ptr);
         ptr[size]=u8'\n';
         orelease(obf,ptr+(++size));
       }

--- a/src/file-int-benchmark.cc
+++ b/src/file-int-benchmark.cc
@@ -259,7 +259,7 @@ struct Data {
     for (int i = 1; i < 11; ++i) fmt::print("{:2} {:6}\n", i, counts[i]);
   }
 
-  Data() : values(100000) {
+  Data() : values(1'000'000) {
     // Similar data as in Boost Karma int generator test:
     // https://www.boost.org/doc/libs/1_63_0/libs/spirit/workbench/karma/int_generator.cpp
     // with rand replaced by uniform_int_distribution for consistent results
@@ -446,7 +446,8 @@ void u2985907(benchmark::State& state) {
     for (auto value : data) {
       char buffer[13];
       unsigned size = u2985907_itoa10(value, buffer);
-      println(obf,buffer,buffer+size);
+      buffer[size]=u8'\n';
+      write(obf,buffer,buffer+(++size));
     }
   }
 }

--- a/src/file-int-benchmark.cc
+++ b/src/file-int-benchmark.cc
@@ -469,9 +469,9 @@ void stout_ltoa(benchmark::State& state) {
   fast_io::obuf_file obf("stout_ltoa.txt");
   for (auto s : state) {
     for (auto value : data) {
-      char buffer[13];
-      ltoa(value, buffer, 13);
-      print(obf,fast_io::chvw(buffer));
+      char buffer[12];
+      ltoa(value, buffer, 12);
+      println(obf,fast_io::chvw(buffer));
       // ltoa doesn't give the size so this invokes strlen.
     }
   }

--- a/src/file-int-benchmark.cc
+++ b/src/file-int-benchmark.cc
@@ -259,7 +259,7 @@ struct Data {
     for (int i = 1; i < 11; ++i) fmt::print("{:2} {:6}\n", i, counts[i]);
   }
 
-  Data() : values(1'000'000) {
+  Data() : values(100000) {
     // Similar data as in Boost Karma int generator test:
     // https://www.boost.org/doc/libs/1_63_0/libs/spirit/workbench/karma/int_generator.cpp
     // with rand replaced by uniform_int_distribution for consistent results

--- a/src/file-int-benchmark.cc
+++ b/src/file-int-benchmark.cc
@@ -485,16 +485,16 @@ void std_to_chars_fast(benchmark::State& state) {
       auto ptr=oreserve(obf,13);
       if(ptr)[[likely]]
       {
-        unsigned size = std::to_chars(ptr,ptr+13,value);
-        ptr[size]=u8'\n';
-        orelease(obf,ptr+(++size));
+        auto res = std::to_chars(buffer, buffer + 13, value);
+        *res.ptr=u8'\n';
+        orelease(obf,res.ptr+1);
       }
       else
       {
         char buffer[13];
-        unsigned size = std::to_chars(ptr,ptr+13,value);
-        buffer[size]=u8'\n';
-        write(obf,buffer,buffer+(++size));
+        auto res = std::to_chars(buffer, buffer + sizeof(buffer), value);
+        *res.ptr=u8'\n';
+        write(obf,buffer,res.ptr+1);
       }
     }
   }

--- a/src/file-int-benchmark.cc
+++ b/src/file-int-benchmark.cc
@@ -512,7 +512,7 @@ void fast_io_println(benchmark::State& state) {
   fast_io::obuf_file obf("fast_io_println.txt");
   for (auto s : state) {
     for (auto value : data) {
-      println(obf,rsv);
+      println(obf,value);
     }
   }
 }

--- a/src/int-benchmark-in-order.cc
+++ b/src/int-benchmark-in-order.cc
@@ -1,0 +1,524 @@
+// A decimal integer to string conversion benchmark
+//
+// Copyright (c) 2019 - present, Victor Zverovich
+// All rights reserved.
+
+#include <benchmark/benchmark.h>
+#include <fmt/compile.h>
+
+#include <algorithm>
+#include <boost/format.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/spirit/include/karma.hpp>
+#include <charconv>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+#include <numeric>
+#include <random>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#if __cpp_lib_concepts>=201907L
+#define FAST_IO_FMT_BENCHMARK
+#include "../fast_io/include/fast_io.h"
+#endif
+
+#include "itostr.cc"
+
+// The method by StackOverflow user
+// https://stackoverflow.com/users/2985907/user2985907 sometimes incorrectly
+// attributed to jiaendu: https://stackoverflow.com/a/19944488/471164
+inline int u2985907_utoa10(unsigned int value, char* str) {
+#define JOIN(N) \
+  N "0", N "1", N "2", N "3", N "4", N "5", N "6", N "7", N "8", N "9"
+
+#define JOIN2(N)                                                   \
+  JOIN(N "0"), JOIN(N "1"), JOIN(N "2"), JOIN(N "3"), JOIN(N "4"), \
+      JOIN(N "5"), JOIN(N "6"), JOIN(N "7"), JOIN(N "8"), JOIN(N "9")
+
+#define JOIN3(N)                                                        \
+  JOIN2(N "0"), JOIN2(N "1"), JOIN2(N "2"), JOIN2(N "3"), JOIN2(N "4"), \
+      JOIN2(N "5"), JOIN2(N "6"), JOIN2(N "7"), JOIN2(N "8"), JOIN2(N "9")
+
+#define JOIN4                                                             \
+  JOIN3("0"), JOIN3("1"), JOIN3("2"), JOIN3("3"), JOIN3("4"), JOIN3("5"), \
+      JOIN3("6"), JOIN3("7"), JOIN3("8"), JOIN3("9")
+
+#define JOIN5(N)                                                            \
+  JOIN(N), JOIN(N "1"), JOIN(N "2"), JOIN(N "3"), JOIN(N "4"), JOIN(N "5"), \
+      JOIN(N "6"), JOIN(N "7"), JOIN(N "8"), JOIN(N "9")
+
+#define JOIN6                                                            \
+  JOIN5(""), JOIN2("1"), JOIN2("2"), JOIN2("3"), JOIN2("4"), JOIN2("5"), \
+      JOIN2("6"), JOIN2("7"), JOIN2("8"), JOIN2("9")
+
+#define F(N) ((N) >= 100 ? 3 : (N) >= 10 ? 2 : 1)
+
+#define F10(N)                                                                \
+  F(N), F(N + 1), F(N + 2), F(N + 3), F(N + 4), F(N + 5), F(N + 6), F(N + 7), \
+      F(N + 8), F(N + 9)
+
+#define F100(N)                                                            \
+  F10(N), F10(N + 10), F10(N + 20), F10(N + 30), F10(N + 40), F10(N + 50), \
+      F10(N + 60), F10(N + 70), F10(N + 80), F10(N + 90)
+
+  static const short offsets[] = {F100(0),   F100(100), F100(200), F100(300),
+                                  F100(400), F100(500), F100(600), F100(700),
+                                  F100(800), F100(900)};
+
+  static const char table1[][4] = {JOIN("")};
+  static const char table2[][4] = {JOIN2("")};
+  static const char table3[][4] = {JOIN3("")};
+  static const char table4[][8] = {JOIN4};
+  static const char table5[][4] = {JOIN6};
+
+#undef JOIN
+#undef JOIN2
+#undef JOIN3
+#undef JOIN4
+#undef F
+#undef F10
+#undef F100
+
+  char* wstr;
+#if (_WIN64 || __x86_64__ || __ppc64__)
+  uint64_t remains[2];
+#else
+  uint32_t remains[2];
+#endif
+  unsigned int v2;
+
+  if (value >= 100000000) {
+#if (_WIN64 || __x86_64__ || __ppc64__)
+    remains[0] = (((uint64_t)value * (uint64_t)3518437209) >> 45);
+    remains[1] = (((uint64_t)value * (uint64_t)2882303762) >> 58);
+#else
+    remains[0] = value / 10000;
+    remains[1] = value / 100000000;
+#endif
+    v2 = remains[1];
+    remains[1] = remains[0] - remains[1] * 10000;
+    remains[0] = value - remains[0] * 10000;
+    if (v2 >= 10) {
+      memcpy(str, table5[v2], 2);
+      str += 2;
+      memcpy(str, table4[remains[1]], 4);
+      str += 4;
+      memcpy(str, table4[remains[0]], 4);
+      return 10;
+    } else {
+      *(char*)str = v2 + '0';
+      str += 1;
+      memcpy(str, table4[remains[1]], 4);
+      str += 4;
+      memcpy(str, table4[remains[0]], 4);
+      return 9;
+    }
+  } else if (value >= 10000) {
+#if (_WIN64 || __x86_64__ || __ppc64__)
+    v2 = (((uint64_t)value * (uint64_t)3518437209) >> 45);
+#else
+    v2 = value / 10000;
+#endif
+    remains[0] = value - v2 * 10000;
+    if (v2 >= 1000) {
+      memcpy(str, table4[v2], 4);
+      str += 4;
+      memcpy(str, table4[remains[0]], 4);
+      return 8;
+    } else {
+      wstr = str;
+      memcpy(wstr, table5[v2], 4);
+      wstr += offsets[v2];
+      memcpy(wstr, table4[remains[0]], 4);
+      wstr += 4;
+      return (wstr - str);
+    }
+  } else {
+    if (value >= 1000) {
+      memcpy(str, table4[value], 4);
+      return 4;
+    } else if (value >= 100) {
+      memcpy(str, table3[value], 3);
+      return 3;
+    } else if (value >= 10) {
+      memcpy(str, table2[value], 2);
+      return 2;
+    } else {
+      *(char*)str = *(char*)table1[value];
+      return 1;
+    }
+  }
+}
+
+int u2985907_itoa10(int value, char* str) {
+  if (value < 0) { *(str++) = '-'; 
+    return u2985907_utoa10(-value, str) + 1; 
+  }
+  else return u2985907_utoa10(value, str);
+}
+
+// Integer to string converter by Alf P. Steinbach modified to return a pointer
+// past the end of the output to avoid calling strlen.
+namespace cppx {
+inline auto unsigned_to_decimal(unsigned long number, char* buffer) {
+  if (number == 0) {
+    *buffer++ = '0';
+  } else {
+    char* p_first = buffer;
+    while (number != 0) {
+      *buffer++ = '0' + number % 10;
+      number /= 10;
+    }
+    std::reverse(p_first, buffer);
+  }
+  *buffer = '\0';
+  return buffer;
+}
+
+inline auto to_decimal(long number, char* buffer) {
+  if (number < 0) {
+    buffer[0] = '-';
+    return unsigned_to_decimal(-number, buffer + 1);
+  } else {
+    return unsigned_to_decimal(number, buffer);
+  }
+}
+
+inline auto decimal_from(long number, char* buffer) {
+  return to_decimal(number, buffer);
+}
+}  // namespace cppx
+
+// Public domain ltoa by Robert B. Stout dba MicroFirm.
+char* ltoa(long N, char* str, int base) {
+  int i = 2;
+  long uarg;
+  constexpr auto BUFSIZE = (sizeof(long) * 8 + 1);
+  char *tail, *head = str, buf[BUFSIZE];
+
+  if (36 < base || 2 > base) base = 10; /* can only use 0-9, A-Z        */
+  tail = &buf[BUFSIZE - 1];             /* last character position      */
+  *tail-- = '\0';
+
+  if (10 == base && N < 0L) {
+    *head++ = '-';
+    uarg = -N;
+  } else
+    uarg = N;
+
+  if (uarg) {
+    for (i = 1; uarg; ++i) {
+      ldiv_t r;
+
+      r = ldiv(uarg, base);
+      *tail-- = (char)(r.rem + ((9L < r.rem) ? ('A' - 10L) : '0'));
+      uarg = r.quot;
+    }
+  } else
+    *tail-- = '0';
+
+  memcpy(head, ++tail, i);
+  return str;
+}
+
+// Computes a digest of data. It is used both to prevent compiler from
+// optimizing away the benchmarked code and to verify that the results are
+// correct. The overhead is less than 2.5% compared to just DoNotOptimize.
+FMT_INLINE unsigned compute_digest(fmt::string_view data) {
+  unsigned digest = 0;
+  for (char c : data) digest += c;
+  return digest;
+}
+
+struct Data {
+  std::vector<int> values;
+  unsigned digest;
+
+  auto begin() const { return values.begin(); }
+  auto end() const { return values.end(); }
+
+  // Prints the number of values by digit count, e.g.
+  //  1  27263
+  //  2 247132
+  //  3 450601
+  //  4 246986
+  //  5  25188
+  //  6   2537
+  //  7    251
+  //  8     39
+  //  9      2
+  // 10      1
+  void print_digit_counts() const {
+    int counts[11] = {};
+    for (auto value : values) ++counts[fmt::format_int(value).size()];
+    fmt::print("The number of values by digit count:\n");
+    for (int i = 1; i < 11; ++i) fmt::print("{:2} {:6}\n", i, counts[i]);
+  }
+
+  Data() : values(1'000'000) {
+    // Similar data as in Boost Karma int generator test:
+    // https://www.boost.org/doc/libs/1_63_0/libs/spirit/workbench/karma/int_generator.cpp
+    // with rand replaced by uniform_int_distribution for consistent results
+    // across platforms.
+    for(int i{};i!=values.size();++i)
+      values[i]=i;
+    digest =
+        std::accumulate(begin(), end(), unsigned(), [](unsigned lhs, int rhs) {
+          char buffer[12];
+          unsigned size = std::sprintf(buffer, "%d", rhs);
+          return lhs + compute_digest({buffer, size});
+        });
+    print_digit_counts();
+  }
+} data;
+
+struct DigestChecker {
+  benchmark::State& state;
+  unsigned digest = 0;
+
+  explicit DigestChecker(benchmark::State& s) : state(s) {}
+
+  ~DigestChecker() noexcept(false) {
+    if (digest != static_cast<unsigned>(state.iterations()) * data.digest)
+      throw std::logic_error("invalid length");
+    state.SetItemsProcessed(state.iterations() * data.values.size());
+    benchmark::DoNotOptimize(digest);
+  }
+
+  FMT_INLINE void add(fmt::string_view s) { digest += compute_digest(s); }
+};
+
+void sprintf(benchmark::State& state) {
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[12];
+      unsigned size = std::sprintf(buffer, "%d", value);
+      dc.add({buffer, size});
+    }
+  }
+}
+BENCHMARK(sprintf);
+
+void std_ostringstream(benchmark::State& state) {
+  auto dc = DigestChecker(state);
+  std::ostringstream os;
+  for (auto s : state) {
+    for (auto value : data) {
+      os.str(std::string());
+      os << value;
+      std::string s = os.str();
+      dc.add(s);
+    }
+  }
+}
+BENCHMARK(std_ostringstream);
+
+void std_to_string(benchmark::State& state) {
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      std::string s = std::to_string(value);
+      dc.add(s);
+    }
+  }
+}
+BENCHMARK(std_to_string);
+
+void std_to_chars(benchmark::State& state) {
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[12];
+      auto res = std::to_chars(buffer, buffer + sizeof(buffer), value);
+      unsigned size = res.ptr - buffer;
+      dc.add({buffer, size});
+    }
+  }
+}
+BENCHMARK(std_to_chars);
+
+void fmt_to_string(benchmark::State& state) {
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      std::string s = fmt::to_string(value);
+      dc.add(s);
+    }
+  }
+}
+BENCHMARK(fmt_to_string);
+
+void fmt_format_runtime(benchmark::State& state) {
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      std::string s = fmt::format("{}", value);
+      dc.add(s);
+    }
+  }
+}
+BENCHMARK(fmt_format_runtime);
+
+void fmt_format_compile(benchmark::State& state) {
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      std::string s = fmt::format(FMT_COMPILE("{}"), value);
+      dc.add(s);
+    }
+  }
+}
+BENCHMARK(fmt_format_compile);
+
+void fmt_format_to_runtime(benchmark::State& state) {
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[12];
+      auto end = fmt::format_to(buffer, "{}", value);
+      unsigned size = end - buffer;
+      dc.add({buffer, size});
+    }
+  }
+}
+BENCHMARK(fmt_format_to_runtime);
+
+void fmt_format_to_compile(benchmark::State& state) {
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[12];
+      constexpr auto f = fmt::compile<int>(FMT_STRING("{}"));
+      auto end = fmt::format_to(buffer, f, value);
+      unsigned size = end - buffer;
+      dc.add({buffer, size});
+    }
+  }
+}
+BENCHMARK(fmt_format_to_compile);
+
+void fmt_format_int(benchmark::State& state) {
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      auto f = fmt::format_int(value);
+      dc.add({f.data(), f.size()});
+    }
+  }
+}
+BENCHMARK(fmt_format_int);
+
+void boost_lexical_cast(benchmark::State& state) {
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      std::string s = boost::lexical_cast<std::string>(value);
+      dc.add(s);
+    }
+  }
+}
+BENCHMARK(boost_lexical_cast);
+
+void boost_format(benchmark::State& state) {
+  auto dc = DigestChecker(state);
+  boost::format fmt("%d");
+  for (auto s : state) {
+    for (auto value : data) {
+      std::string s = boost::str(fmt % value);
+      dc.add(s);
+    }
+  }
+}
+BENCHMARK(boost_format);
+
+void boost_karma_generate(benchmark::State& state) {
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[12];
+      char* ptr = buffer;
+      boost::spirit::karma::generate(ptr, boost::spirit::karma::int_, value);
+      unsigned size = ptr - buffer;
+      dc.add({buffer, size});
+    }
+  }
+}
+BENCHMARK(boost_karma_generate);
+
+void voigt_itostr(benchmark::State& state) {
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      std::string s = itostr(value);
+      dc.add(s);
+    }
+  }
+}
+BENCHMARK(voigt_itostr);
+
+void u2985907(benchmark::State& state) {
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[12];
+      unsigned size = u2985907_itoa10(value, buffer);
+      dc.add({buffer, size});
+    }
+  }
+}
+BENCHMARK(u2985907);
+
+void decimal_from(benchmark::State& state) {
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[12];
+      auto end = cppx::decimal_from(value, buffer);
+      unsigned size = end - buffer;
+      dc.add({buffer, size});
+    }
+  }
+}
+BENCHMARK(decimal_from);
+
+void stout_ltoa(benchmark::State& state) {
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      char buffer[12];
+      ltoa(value, buffer, 10);
+      // ltoa doesn't give the size so this invokes strlen.
+      dc.add(buffer);
+    }
+  }
+}
+BENCHMARK(stout_ltoa);
+
+#if __cpp_lib_concepts>=201907L
+void fast_io_concat(benchmark::State& state) {
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      dc.add(fast_io::concat(value));
+    }
+  }
+}
+BENCHMARK(fast_io_concat);
+void fast_io_print_reserve(benchmark::State& state) {
+//  fast_io::ostring_ref ostr(str);
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      auto rsv(fast_io::print_reserve(value));
+      dc.add({rsv.data(),rsv.size()});
+    }
+  }
+}
+BENCHMARK(fast_io_print_reserve);
+#endif
+
+BENCHMARK_MAIN();

--- a/src/int-benchmark.cc
+++ b/src/int-benchmark.cc
@@ -521,7 +521,7 @@ void fast_io_ospan(benchmark::State& state) {
     for (auto value : data) {
       fast_io::ospan osp(buffer);
       print(osp,value);
-      dc.add({osp.data(),osp.size()});
+      dc.add({osp.span().data(),osp.span().size()});
     }
   }
 }

--- a/src/int-benchmark.cc
+++ b/src/int-benchmark.cc
@@ -513,7 +513,6 @@ void fast_io_concat(benchmark::State& state) {
 }
 BENCHMARK(fast_io_concat);
 void fast_io_ospan(benchmark::State& state) {
-  std::string str;
   std::array<char,40> buffer;
 
 //  fast_io::ostring_ref ostr(str);
@@ -525,7 +524,7 @@ void fast_io_ospan(benchmark::State& state) {
     }
   }
 }
-BENCHMARK(fast_io_ostring_ref);
+BENCHMARK(fast_io_ospan);
 #endif
 
 BENCHMARK_MAIN();

--- a/src/int-benchmark.cc
+++ b/src/int-benchmark.cc
@@ -521,7 +521,7 @@ void fast_io_ospan(benchmark::State& state) {
     for (auto value : data) {
       fast_io::ospan osp(buffer);
       print(osp,value);
-      dc.add({osp.span().data(),osp.span().size()});
+      dc.add({osp.span().data(),osize(osp)});
     }
   }
 }

--- a/src/int-benchmark.cc
+++ b/src/int-benchmark.cc
@@ -21,6 +21,7 @@
 #include <vector>
 
 #if __cpp_lib_concepts>=201907L
+#define FAST_IO_FMT_BENCHMARK
 #include "../fast_io/include/fast_io.h"
 #endif
 
@@ -512,20 +513,17 @@ void fast_io_concat(benchmark::State& state) {
   }
 }
 BENCHMARK(fast_io_concat);
-void fast_io_ospan(benchmark::State& state) {
-  std::array<char,40> buffer;
-
+void fast_io_print_reserve(benchmark::State& state) {
 //  fast_io::ostring_ref ostr(str);
   auto dc = DigestChecker(state);
   for (auto s : state) {
     for (auto value : data) {
-      fast_io::ospan osp(buffer);
-      print(osp,value);
-      dc.add({osp.span().data(),osize(osp)});
+      auto rsv(fast_io::print_reserve(data));
+      dc.add({rsv.data(),rsv.size()});
     }
   }
 }
-BENCHMARK(fast_io_ospan);
+BENCHMARK(fast_io_print_reserve);
 #endif
 
 BENCHMARK_MAIN();

--- a/src/int-benchmark.cc
+++ b/src/int-benchmark.cc
@@ -512,16 +512,16 @@ void fast_io_concat(benchmark::State& state) {
   }
 }
 BENCHMARK(fast_io_concat);
-
-void fast_io_ostring_ref(benchmark::State& state) {
+void fast_io_ospan(benchmark::State& state) {
   std::string str;
-  fast_io::ostring_ref ostr(str);
+  std::array<char,40> buffer;
+
+//  fast_io::ostring_ref ostr(str);
   auto dc = DigestChecker(state);
   for (auto s : state) {
     for (auto value : data) {
-      obuffer_set_curr(ostr,obuffer_begin(ostr));
-      print(ostr,value);
-      dc.add(str);
+      fast_io::ospan<char> osp(buffer);
+      print(osp,value);
     }
   }
 }

--- a/src/int-benchmark.cc
+++ b/src/int-benchmark.cc
@@ -519,8 +519,9 @@ void fast_io_ospan(benchmark::State& state) {
   auto dc = DigestChecker(state);
   for (auto s : state) {
     for (auto value : data) {
-      fast_io::ospan<char> osp(buffer);
+      fast_io::ospan osp(buffer);
       print(osp,value);
+      dc.add({osp.data(),osp.size()});
     }
   }
 }

--- a/src/int-benchmark.cc
+++ b/src/int-benchmark.cc
@@ -346,30 +346,6 @@ void std_to_chars(benchmark::State& state) {
 }
 BENCHMARK(std_to_chars);
 
-
-#if __cpp_lib_concepts>=201907L
-void fast_io_concat(benchmark::State& state) {
-  auto dc = DigestChecker(state);
-  for (auto s : state) {
-    for (auto value : data) {
-      dc.add(fast_io::concat(value));
-    }
-  }
-}
-BENCHMARK(fast_io_concat);
-void fast_io_print_reserve(benchmark::State& state) {
-//  fast_io::ostring_ref ostr(str);
-  auto dc = DigestChecker(state);
-  for (auto s : state) {
-    for (auto value : data) {
-      auto rsv(fast_io::print_reserve(value));
-      dc.add({rsv.data(),rsv.size()});
-    }
-  }
-}
-BENCHMARK(fast_io_print_reserve);
-#endif
-
 void fmt_to_string(benchmark::State& state) {
   auto dc = DigestChecker(state);
   for (auto s : state) {
@@ -526,5 +502,28 @@ void stout_ltoa(benchmark::State& state) {
   }
 }
 BENCHMARK(stout_ltoa);
+
+#if __cpp_lib_concepts>=201907L
+void fast_io_concat(benchmark::State& state) {
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      dc.add(fast_io::concat(value));
+    }
+  }
+}
+BENCHMARK(fast_io_concat);
+void fast_io_print_reserve(benchmark::State& state) {
+//  fast_io::ostring_ref ostr(str);
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      auto rsv(fast_io::print_reserve(value));
+      dc.add({rsv.data(),rsv.size()});
+    }
+  }
+}
+BENCHMARK(fast_io_print_reserve);
+#endif
 
 BENCHMARK_MAIN();

--- a/src/int-benchmark.cc
+++ b/src/int-benchmark.cc
@@ -20,6 +20,10 @@
 #include <string>
 #include <vector>
 
+#ifdef __cpp_lib_concepts>=201907L
+#include "../fast_io/include/fast_io.h"
+#endif
+
 #include "itostr.cc"
 
 // The method by StackOverflow user
@@ -497,5 +501,31 @@ void stout_ltoa(benchmark::State& state) {
   }
 }
 BENCHMARK(stout_ltoa);
+
+#ifdef __cpp_lib_concepts>=201907L
+void fast_io_concat(benchmark::State& state) {
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      dc.add(fast_io::concat(value));
+    }
+  }
+}
+BENCHMARK(fast_io_concat);
+
+void fast_io_ostring_ref(benchmark::State& state) {
+  std::string str;
+  fast_io::ostring_ref ostr(str);
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      obuffer_set_curr(ostr,obuffer_begin(ostr));
+      print(ostr,value);
+      dc.add(str);
+    }
+  }
+}
+BENCHMARK(fast_io_ostring_ref);
+#endif
 
 BENCHMARK_MAIN();

--- a/src/int-benchmark.cc
+++ b/src/int-benchmark.cc
@@ -346,6 +346,30 @@ void std_to_chars(benchmark::State& state) {
 }
 BENCHMARK(std_to_chars);
 
+
+#if __cpp_lib_concepts>=201907L
+void fast_io_concat(benchmark::State& state) {
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      dc.add(fast_io::concat(value));
+    }
+  }
+}
+BENCHMARK(fast_io_concat);
+void fast_io_print_reserve(benchmark::State& state) {
+//  fast_io::ostring_ref ostr(str);
+  auto dc = DigestChecker(state);
+  for (auto s : state) {
+    for (auto value : data) {
+      auto rsv(fast_io::print_reserve(value));
+      dc.add({rsv.data(),rsv.size()});
+    }
+  }
+}
+BENCHMARK(fast_io_print_reserve);
+#endif
+
 void fmt_to_string(benchmark::State& state) {
   auto dc = DigestChecker(state);
   for (auto s : state) {
@@ -502,28 +526,5 @@ void stout_ltoa(benchmark::State& state) {
   }
 }
 BENCHMARK(stout_ltoa);
-
-#if __cpp_lib_concepts>=201907L
-void fast_io_concat(benchmark::State& state) {
-  auto dc = DigestChecker(state);
-  for (auto s : state) {
-    for (auto value : data) {
-      dc.add(fast_io::concat(value));
-    }
-  }
-}
-BENCHMARK(fast_io_concat);
-void fast_io_print_reserve(benchmark::State& state) {
-//  fast_io::ostring_ref ostr(str);
-  auto dc = DigestChecker(state);
-  for (auto s : state) {
-    for (auto value : data) {
-      auto rsv(fast_io::print_reserve(value));
-      dc.add({rsv.data(),rsv.size()});
-    }
-  }
-}
-BENCHMARK(fast_io_print_reserve);
-#endif
 
 BENCHMARK_MAIN();

--- a/src/int-benchmark.cc
+++ b/src/int-benchmark.cc
@@ -518,7 +518,7 @@ void fast_io_print_reserve(benchmark::State& state) {
   auto dc = DigestChecker(state);
   for (auto s : state) {
     for (auto value : data) {
-      auto rsv(fast_io::print_reserve(data));
+      auto rsv(fast_io::print_reserve(value));
       dc.add({rsv.data(),rsv.size()});
     }
   }

--- a/src/int-benchmark.cc
+++ b/src/int-benchmark.cc
@@ -20,7 +20,7 @@
 #include <string>
 #include <vector>
 
-#ifdef __cpp_lib_concepts>=201907L
+#if __cpp_lib_concepts>=201907L
 #include "../fast_io/include/fast_io.h"
 #endif
 
@@ -502,7 +502,7 @@ void stout_ltoa(benchmark::State& state) {
 }
 BENCHMARK(stout_ltoa);
 
-#ifdef __cpp_lib_concepts>=201907L
+#if __cpp_lib_concepts>=201907L
 void fast_io_concat(benchmark::State& state) {
   auto dc = DigestChecker(state);
   for (auto s : state) {


### PR DESCRIPTION
BTW, boost uses std::remove_cvref_t, without C++20, boost format won't compile on GCC.