### PR TITLE
Fix various compilation issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,12 @@ add_executable(vararg-benchmark vararg-benchmark.cc)
 target_link_libraries(vararg-benchmark benchmark fmt)
 
 add_executable(int-benchmark src/int-benchmark.cc)
-target_link_libraries(int-benchmark benchmark Boost::boost fmt)
+target_link_libraries(int-benchmark benchmark fmt)
+if(TARGET Boost::boost)
+  target_link_libraries(int-benchmark Boost::boost)
+  target_compile_options(int-benchmark -DHAVE_BOOST)
+endif()
+
 target_compile_features(int-benchmark PRIVATE cxx_relaxed_constexpr)
 
 add_executable(locale-benchmark src/locale-benchmark.cc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,19 +19,25 @@ include(CheckCXXCompilerFlag)
 # https://www.intel.com/content/dam/support/us/en/documents/processors/
 # mitigations-jump-conditional-code-erratum.pdf
 # to get more reliable benchmark results.
-set(INTEL FALSE)
-if (APPLE)
-  execute_process(COMMAND sysctl -n machdep.cpu.brand_string
-                  OUTPUT_VARIABLE out)
-  if (out MATCHES "Intel.*")
-    set(INTEL TRUE)
+
+if(NOT DEFINED INTEL)
+  if (APPLE)
+    execute_process(COMMAND sysctl -n machdep.cpu.brand_string
+                    OUTPUT_VARIABLE out)
+    if (out MATCHES "Intel.*")
+      option(INTEL "Are we compiling on/for an intel target?" ON)
+    endif ()
+  else ()
+    file(READ /proc/cpuinfo out)
+    if (out MATCHES "(.|\n)*GenuineIntel(.|\n)*")
+      option(INTEL "Are we compiling on/for an intel target?" ON)
+    endif ()
   endif ()
-else ()
-  file(READ /proc/cpuinfo out)
-  if (out MATCHES "(.|\n)*GenuineIntel(.|\n)*")
-    set(INTEL TRUE)
-  endif ()
-endif ()
+
+  # If already set to true, won't be modified
+      option(INTEL "Are we compiling on/for an intel target?" OFF)
+endif()
+
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   # Ideally we should use -mbranches-within-32B-boundaries but it's not widely

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ include(CheckCXXCompilerFlag)
 # mitigations-jump-conditional-code-erratum.pdf
 # to get more reliable benchmark results.
 
-if(NOT DEFINED INTEL)
+if (NOT DEFINED INTEL)
   if (APPLE)
     execute_process(COMMAND sysctl -n machdep.cpu.brand_string
                     OUTPUT_VARIABLE out)
@@ -36,27 +36,29 @@ if(NOT DEFINED INTEL)
 
   # If already set to true, won't be modified
       option(INTEL "Are we compiling on/for an intel target?" OFF)
-endif()
-
-
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  # Ideally we should use -mbranches-within-32B-boundaries but it's not widely
-  # available so at least align loops to prevent unrelated code changes from
-  # affecting benchmark results.
-  set(ALIGN_OPTIONS -mllvm -align-all-blocks=5)
-elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  set(ALIGN_FUNCTION_BYTES 32)
-  set(ALIGN_OPTIONS -falign-functions=${ALIGN_FUNCTION_BYTES})
-elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
-  set(ALIGN_OPTIONS -Wa,-mbranches-within-32B-boundaries)
 endif ()
 
-check_cxx_compiler_flag(${ALIGN_OPTIONS} ALIGN_OPTIONS_WORKS)
-if(NOT ALIGN_OPTIONS_WORKS)
-  set(ALIGN_OPTIONS)
-endif()
+function(check_flags_and_append_on_success test_flags_var_name append_to_var)
+  check_cxx_compiler_flag("${${test_flags_var_name}_FLAGS}" ${test_flags_var_name}_WORKS)
+  if (${test_flags_var_name}_WORKS)
+    list(APPEND ${append_to_var} ${${test_flags_var_name}_FLAGS})
+    set(${append_to_var} ${${append_to_var}} PARENT_SCOPE)
+  endif ()
+endfunction()
 
+# Ideally we should use -mbranches-within-32B-boundaries but it's not widely
+# available so at least align loops/functions as fallback to prevent unrelated
+# code changes from affecting benchmark results.
+set(ALIGN_ALL_BLOCKS_FLAGS -mllvm -align-all-blocks=5)
+set(ALIGN_32B_BOUNDARIES_FLAGS -Wa,-mbranches-within-32B-boundaries)
+set(ALIGN_FUNCTION_BYTES 32)
+set(ALIGN_FUNCTION_FLAGS -falign-functions=${ALIGN_FUNCTION_BYTES})
 
+check_flags_and_append_on_success(ALIGN_32B_BOUNDARIES ALIGN_OPTIONS)
+if (NOT ALIGN_32B_BOUNDARIES_WORKS)
+  check_flags_and_append_on_success(ALIGN_ALL_BLOCKS     ALIGN_OPTIONS)
+  check_flags_and_append_on_success(ALIGN_FUNCTION       ALIGN_OPTIONS)
+endif ()
 
 message(STATUS "Align options: ${ALIGN_OPTIONS}")
 add_definitions(${ALIGN_OPTIONS})
@@ -140,7 +142,7 @@ else()
   COMMAND @echo stb_sprintf timings:
   COMMAND @time -p ./tinyformat_speed_test stb_sprintf > /dev/null
 	DEPENDS tinyformat_speed_test)
-endif()
+endif ()
 
 add_custom_target(bloat-test
                   COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/bloat-test.py -I${Boost_INCLUDE_DIRS}
@@ -160,10 +162,10 @@ target_link_libraries(vararg-benchmark benchmark fmt)
 
 add_executable(int-benchmark src/int-benchmark.cc)
 target_link_libraries(int-benchmark benchmark fmt)
-if(TARGET Boost::boost)
+if (TARGET Boost::boost)
   target_link_libraries(int-benchmark Boost::boost)
   target_compile_options(int-benchmark -DHAVE_BOOST)
-endif()
+endif ()
 
 target_compile_features(int-benchmark PRIVATE cxx_relaxed_constexpr)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.1)
 
 # Set the default CMAKE_BUILD_TYPE to Release.
 # This should be done before the project command since the latter can set

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ project(FORMAT_BENCHMARKS)
 set(CMAKE_MACOSX_RPATH ON)
 set(CMAKE_CXX_STANDARD 17)
 
+include(CheckCXXCompilerFlag)
+
 # Workaround a JCC bug in Intel CPUs:
 # https://www.intel.com/content/dam/support/us/en/documents/processors/
 # mitigations-jump-conditional-code-erratum.pdf
@@ -30,14 +32,26 @@ else ()
     set(INTEL TRUE)
   endif ()
 endif ()
+
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   # Ideally we should use -mbranches-within-32B-boundaries but it's not widely
   # available so at least align loops to prevent unrelated code changes from
   # affecting benchmark results.
   set(ALIGN_OPTIONS -mllvm -align-all-blocks=5)
-else ()
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set(ALIGN_FUNCTION_BYTES 32)
+  set(ALIGN_OPTIONS -falign-functions=${ALIGN_FUNCTION_BYTES})
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
   set(ALIGN_OPTIONS -Wa,-mbranches-within-32B-boundaries)
 endif ()
+
+check_cxx_compiler_flag(${ALIGN_OPTIONS} ALIGN_OPTIONS_WORKS)
+if(NOT ALIGN_OPTIONS_WORKS)
+  set(ALIGN_OPTIONS)
+endif()
+
+
+
 message(STATUS "Align options: ${ALIGN_OPTIONS}")
 add_definitions(${ALIGN_OPTIONS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,21 +21,21 @@ include(CheckCXXCompilerFlag)
 # to get more reliable benchmark results.
 
 if (NOT DEFINED INTEL)
+  set(_IS_INTEL_HOST OFF)
   if (APPLE)
     execute_process(COMMAND sysctl -n machdep.cpu.brand_string
                     OUTPUT_VARIABLE out)
     if (out MATCHES "Intel.*")
-      option(INTEL "Are we compiling on/for an intel target?" ON)
+      set(_IS_INTEL_HOST ON)
     endif ()
   else ()
     file(READ /proc/cpuinfo out)
     if (out MATCHES "(.|\n)*GenuineIntel(.|\n)*")
-      option(INTEL "Are we compiling on/for an intel target?" ON)
+      set(_IS_INTEL_HOST ON)
     endif ()
   endif ()
 
-  # If already set to true, won't be modified
-      option(INTEL "Are we compiling on/for an intel target?" OFF)
+  option(INTEL "Are we compiling on/for an intel target?" ${_IS_INTEL_HOST})
 endif ()
 
 function(check_flags_and_append_on_success test_flags_var_name append_to_var)

--- a/src/int-benchmark.cc
+++ b/src/int-benchmark.cc
@@ -7,9 +7,11 @@
 #include <fmt/compile.h>
 
 #include <algorithm>
+#ifdef HAVE_BOOST
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/spirit/include/karma.hpp>
+#endif
 #include <charconv>
 #include <cstdio>
 #include <cstdlib>
@@ -280,6 +282,7 @@ void fmt_format_int(benchmark::State& state) {
 }
 BENCHMARK(fmt_format_int);
 
+#ifdef HAVE_BOOST
 void boost_lexical_cast(benchmark::State& state) {
   auto dc = DigestChecker(state);
   for (auto s : state) {
@@ -316,6 +319,7 @@ void boost_karma_generate(benchmark::State& state) {
   }
 }
 BENCHMARK(boost_karma_generate);
+#endif
 
 void voigt_itostr(benchmark::State& state) {
   auto dc = DigestChecker(state);

--- a/src/int-benchmark.cc
+++ b/src/int-benchmark.cc
@@ -262,8 +262,7 @@ void fmt_format_to_compile(benchmark::State& state) {
   for (auto s : state) {
     for (auto value : data) {
       char buffer[12];
-      constexpr auto f = fmt::compile<int>(FMT_STRING("{}"));
-      auto end = fmt::format_to(buffer, f, value);
+      auto end = fmt::format_to(buffer, FMT_COMPILE("{}"), value);
       unsigned size = end - buffer;
       dc.add({buffer, size});
     }

--- a/src/itoa-benchmark/CMakeLists.txt
+++ b/src/itoa-benchmark/CMakeLists.txt
@@ -35,14 +35,14 @@ add_executable(
 if (APPLE)
   execute_process(COMMAND sysctl -n machdep.cpu.brand_string
                   OUTPUT_VARIABLE out)
-elseif(UNIX)
+elseif (UNIX)
   file(READ /proc/cpuinfo out)
   string(REGEX MATCH "(model name[^\n]*)" out "${out}")
 endif ()
 
 string(REGEX REPLACE
-        "(model name.*: )|[ |\n]+|(Intel\\(R\\))|\\(TM\\)|\\(R\\)|CPU|@" ""
+        "(model name.*: )|[ |\n]+|(Intel\\(R\\))|\\(TM\\)|\\(R\\)|CPU" ""
         out "${out}")
-if(out)
+if (out)
   target_compile_definitions(itoa-benchmark PRIVATE MACHINE="${out}")
-endif()
+endif ()

--- a/src/itoa-benchmark/CMakeLists.txt
+++ b/src/itoa-benchmark/CMakeLists.txt
@@ -1,3 +1,4 @@
+
 add_executable(
     itoa-benchmark
     amartin.cpp
@@ -34,11 +35,14 @@ add_executable(
 if (APPLE)
   execute_process(COMMAND sysctl -n machdep.cpu.brand_string
                   OUTPUT_VARIABLE out)
-else ()
+elseif(UNIX)
   file(READ /proc/cpuinfo out)
-  string(REGEX REPLACE "(model name.*)" "\1" out "${out}")
+  string(REGEX MATCH "(model name[^\n]*)" out "${out}")
 endif ()
+
 string(REGEX REPLACE
-        "(model name.*: )|[ |\n]+|(Intel\\(R\\))|\\(TM\\)|\\(R\\)|CPU" ""
+        "(model name.*: )|[ |\n]+|(Intel\\(R\\))|\\(TM\\)|\\(R\\)|CPU|@" ""
         out "${out}")
-target_compile_definitions(itoa-benchmark PRIVATE MACHINE="${out}")
+if(out)
+  target_compile_definitions(itoa-benchmark PRIVATE MACHINE="${out}")
+endif()

--- a/src/parse-benchmark.cc
+++ b/src/parse-benchmark.cc
@@ -63,7 +63,7 @@ FMT_CONSTEXPR const Char* parse_format_specs_z(const Char* begin,
 }
 
 class specs_handler_z
-    : public fmt::internal::specs_handler<fmt::format_parse_context,
+    : public fmt::detail::specs_handler<fmt::format_parse_context,
                                           fmt::format_context> {
  public:
   FMT_CONSTEXPR specs_handler_z(fmt::format_specs& specs,
@@ -83,11 +83,11 @@ void parse(benchmark::State& state) {
   auto arg_store = fmt::make_format_args(42.0);
   auto args = fmt::format_args(arg_store);
   auto ctx = fmt::format_context(
-      std::back_inserter(static_cast<fmt::internal::buffer<char>&>(buf)), args);
+      std::back_inserter(static_cast<fmt::detail::buffer<char>&>(buf)), args);
   auto specs = fmt::basic_format_specs<char>();
-  auto handler = fmt::internal::specs_handler(specs, parse_ctx, ctx);
+  auto handler = fmt::detail::specs_handler(specs, parse_ctx, ctx);
   while (state.KeepRunning()) {
-    fmt::internal::parse_format_specs(format_str.begin(), format_str.end(),
+    fmt::detail::parse_format_specs(format_str.begin(), format_str.end(),
                                       handler);
     benchmark::DoNotOptimize(specs.type);
   }
@@ -101,7 +101,7 @@ void parse_z(benchmark::State& state) {
   auto arg_store = fmt::make_format_args(42.0);
   auto args = fmt::format_args(arg_store);
   auto ctx = fmt::format_context(
-      std::back_inserter(static_cast<fmt::internal::buffer<char>&>(buf)), args);
+      std::back_inserter(static_cast<fmt::detail::buffer<char>&>(buf)), args);
   auto specs = fmt::basic_format_specs<char>();
   auto handler = specs_handler_z(specs, parse_ctx, ctx);
   while (state.KeepRunning()) {


### PR DESCRIPTION
I had a few issues trying to compile the benchmarks, which are fixed by this PR:

- The code was using `fmt::internal` namespace, which is now called details
   - I updated the code to use the `detail` namespace, but maybe I should have defined `FMT_USE_INTERNAL` ?
- `ALIGN_OPTIONS` were only working for clang or intel compilers, now makes sure the flags are supported
- Boost was not `REQUIRED` but used as if always found, instead made it optional with a HAVE_BOOST define
- `constexpr auto f = fmt::compile<int>(FMT_STRING("{}"));` was not compiling (even though it probably still should ?), so I replaced it with the macro `FMT_COMPILE`
- The itoa benchmark regex were not working on my machine, so I updated those. It should probably be detected at runtime though since the same executable could be executed on different machines ?

