### PR TITLE
Add fmt library to itoa-benchmark, improve README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ A collection of formatting benchmarks
 * Speed, compile time and code bloat tests from
   `tinyformat <https://github.com/c42f/tinyformat>`__.
 * ``int-benchmark``: decimal integer to string conversion benchmark from Boost Karma
-* ``itoa-benchmark``: decimal integer to string conversion benchmark by Milo Yip
+* ``itoa-benchmark``: decimal integer to string conversion benchmark by Milo Yip. See `<src/itoa-benchmark/readme.md>`__.
 
 Building and running ``int-benchmark``:
 
@@ -12,7 +12,13 @@ Building and running ``int-benchmark``:
 
    cmake .
    make
-   ./int-benchmarks
+   ./int-benchmark
+
+Alternatively (requires ``ninja``)::
+
+   cmake -G Ninja .
+   ninja int-benchmark
+   ./int-benchmark
 
 Sample results on macOS with clang and libc++:
 

--- a/src/itoa-benchmark/CMakeLists.txt
+++ b/src/itoa-benchmark/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(
     countlut.cpp
     digitslut.h
     folly.cpp
+    fmt.cpp
     itoa_jeaiii.cpp
     itoa_jeaiii_bind.cpp
     itoa_ljust.h
@@ -31,6 +32,7 @@ add_executable(
     unnamed.cpp
     unrolledlut.cpp
     vc.cpp)
+target_link_libraries(itoa-benchmark fmt)
 
 if (APPLE)
   execute_process(COMMAND sysctl -n machdep.cpu.brand_string

--- a/src/itoa-benchmark/fmt.cpp
+++ b/src/itoa-benchmark/fmt.cpp
@@ -1,0 +1,21 @@
+#include <stdint.h>
+#include <fmt/compile.h>
+#include "test.h"
+
+void u32toa_fmt(uint32_t value, char* buffer) {
+    *fmt::format_to(buffer, FMT_COMPILE("{}"), value) = '\0';
+}
+
+void i32toa_fmt(int32_t value, char* buffer) {
+    *fmt::format_to(buffer, FMT_COMPILE("{}"), value) = '\0';
+}
+
+void u64toa_fmt(uint64_t value, char* buffer) {
+    *fmt::format_to(buffer, FMT_COMPILE("{}"), value) = '\0';
+}
+
+void i64toa_fmt(int64_t value, char* buffer) {
+    *fmt::format_to(buffer, FMT_COMPILE("{}"), value) = '\0';
+}
+
+REGISTER_TEST(fmt);


### PR DESCRIPTION
Mostly for convenience. If I understood correctly, `fmt` is pretty much `countlut`.

It works because this `CMakeLists.txt` is only read by the one two directories above, which `add_subdirectory(fmt)`.

Not sure if `target_link_libraries` is the correct CMake macro to use, but it works and `int-benchmark` also use that.

<details><summary>Example output</summary>

```
Verifying naive_u32toa = amartin ... OK
Verifying naive_i32toa = amartin ... OK
Verifying naive_u64toa = amartin ... OK
Verifying naive_i64toa = amartin ... OK
Verifying naive_u32toa = branchlut ... OK
Verifying naive_i32toa = branchlut ... OK
Verifying naive_u64toa = branchlut ... OK
Verifying naive_i64toa = branchlut ... OK
Verifying naive_u32toa = branchlut2 ... OK
Verifying naive_i32toa = branchlut2 ... OK
Verifying naive_u64toa = branchlut2 ... OK
Verifying naive_i64toa = branchlut2 ... OK
Verifying naive_u32toa = count ... OK
Verifying naive_i32toa = count ... OK
Verifying naive_u64toa = count ... OK
Verifying naive_i64toa = count ... OK
Verifying naive_u32toa = countlut ... OK
Verifying naive_i32toa = countlut ... OK
Verifying naive_u64toa = countlut ... OK
Verifying naive_i64toa = countlut ... OK
Verifying naive_u32toa = fmt ... OK
Verifying naive_i32toa = fmt ... OK
Verifying naive_u64toa = fmt ... OK
Verifying naive_i64toa = fmt ... OK
Verifying naive_u32toa = jeaiii ... OK
Verifying naive_i32toa = jeaiii ... OK
Verifying naive_u64toa = jeaiii ... OK
Verifying naive_i64toa = jeaiii ... OK
Verifying naive_u32toa = lut ... OK
Verifying naive_i32toa = lut ... OK
Verifying naive_u64toa = lut ... OK
Verifying naive_i64toa = lut ... OK
Verifying naive_u32toa = mwilson ... OK
Verifying naive_i32toa = mwilson ... OK
Verifying naive_u64toa = mwilson ... OK
Verifying naive_i64toa = mwilson ... OK
Verifying naive_u32toa = naive ... OK
Verifying naive_i32toa = naive ... OK
Verifying naive_u64toa = naive ... OK
Verifying naive_i64toa = naive ... OK
Verifying naive_u32toa = sprintf ... OK
Verifying naive_i32toa = sprintf ... OK
Verifying naive_u64toa = sprintf ... OK
Verifying naive_i64toa = sprintf ... OK
Verifying naive_u32toa = sse2 ... OK
Verifying naive_i32toa = sse2 ... OK
Verifying naive_u64toa = sse2 ... OK
Verifying naive_i64toa = sse2 ... OK
Verifying naive_u32toa = tmueller ... OK
Verifying naive_i32toa = tmueller ... OK
Verifying naive_u64toa = tmueller ... OK
Verifying naive_i64toa = tmueller ... OK
Verifying naive_u32toa = unnamed ... OK
Verifying naive_i32toa = unnamed ... OK
Verifying naive_u64toa = unnamed ... OK
Verifying naive_i64toa = unnamed ... OK
Verifying naive_u32toa = unrolledlut ... OK
Verifying naive_i32toa = unrolledlut ... OK
Verifying naive_u64toa = unrolledlut ... OK
Verifying naive_i64toa = unrolledlut ... OK
u32toa
Benchmarking sequential amartin              ... [   2.420ns,    5.530ns]
Benchmarking     random amartin              ...    8.528ns
Benchmarking sequential branchlut            ... [   2.760ns,    9.090ns]
Benchmarking     random branchlut            ...   13.406ns
Benchmarking sequential branchlut2           ... [   3.450ns,   10.650ns]
Benchmarking     random branchlut2           ...   14.526ns
Benchmarking sequential count                ... [   3.450ns,   14.940ns]
Benchmarking     random count                ...   16.433ns
Benchmarking sequential countlut             ... [   2.760ns,    7.810ns]
Benchmarking     random countlut             ...   13.047ns
Benchmarking sequential fmt                  ... [   3.110ns,    7.950ns]
Benchmarking     random fmt                  ...   13.030ns
Benchmarking sequential jeaiii               ... [   1.730ns,    5.530ns]
Benchmarking     random jeaiii               ...   12.401ns
Benchmarking sequential lut                  ... [   3.450ns,   13.850ns]
Benchmarking     random lut                  ...   16.678ns
Benchmarking sequential mwilson              ... [   3.450ns,   19.400ns]
Benchmarking     random mwilson              ...   18.187ns
Benchmarking sequential naive                ... [   4.140ns,   19.190ns]
Benchmarking     random naive                ...   18.739ns
Benchmarking sequential null                 ... [   1.720ns,    2.070ns]
Benchmarking     random null                 ...    1.734ns
Benchmarking sequential sprintf              ... [  46.480ns,   58.640ns]
Benchmarking     random sprintf              ...   66.243ns
Benchmarking sequential sse2                 ... [   2.420ns,    6.910ns]
Benchmarking     random sse2                 ...   12.614ns
Benchmarking sequential tmueller             ... [   2.080ns,    5.880ns]
Benchmarking     random tmueller             ...    9.646ns
Benchmarking sequential unnamed              ... [   4.150ns,   11.780ns]
Benchmarking     random unnamed              ...   15.603ns
Benchmarking sequential unrolledlut          ... [   2.760ns,    5.870ns]
Benchmarking     random unrolledlut          ...   11.557ns

i32toa
Benchmarking sequential amartin              ... [   3.450ns,    7.200ns]
Benchmarking     random amartin              ...    9.849ns
Benchmarking sequential branchlut            ... [   3.280ns,    9.670ns]
Benchmarking     random branchlut            ...   17.073ns
Benchmarking sequential branchlut2           ... [   3.450ns,   11.490ns]
Benchmarking     random branchlut2           ...   17.495ns
Benchmarking sequential count                ... [   4.150ns,   15.500ns]
Benchmarking     random count                ...   19.409ns
Benchmarking sequential countlut             ... [   3.450ns,    8.440ns]
Benchmarking     random countlut             ...   16.316ns
Benchmarking sequential fmt                  ... [   3.630ns,    8.670ns]
Benchmarking     random fmt                  ...   16.470ns
Benchmarking sequential jeaiii               ... [   2.590ns,    5.880ns]
Benchmarking     random jeaiii               ...   15.523ns
Benchmarking sequential lut                  ... [   4.150ns,   14.590ns]
Benchmarking     random lut                  ...   20.850ns
Benchmarking sequential mwilson              ... [   4.490ns,   27.810ns]
Benchmarking     random mwilson              ...   25.943ns
Benchmarking sequential naive                ... [   4.580ns,   19.880ns]
Benchmarking     random naive                ...   22.444ns
Benchmarking sequential null                 ... [   1.720ns,    2.070ns]
Benchmarking     random null                 ...    1.731ns
Benchmarking sequential sprintf              ... [  47.730ns,   60.770ns]
Benchmarking     random sprintf              ...   71.342ns
Benchmarking sequential sse2                 ... [   3.280ns,    7.600ns]
Benchmarking     random sse2                 ...   15.964ns
Benchmarking sequential tmueller             ... [   2.760ns,    6.960ns]
Benchmarking     random tmueller             ...   10.764ns
Benchmarking sequential unnamed              ... [   5.180ns,   12.810ns]
Benchmarking     random unnamed              ...   19.696ns
Benchmarking sequential unrolledlut          ... [   3.280ns,    6.220ns]
Benchmarking     random unrolledlut          ...   14.897ns

u64toa
Benchmarking sequential amartin              ... [   2.760ns,   11.310ns]
Benchmarking     random amartin              ...   15.731ns
Benchmarking sequential branchlut            ... [   3.110ns,   20.070ns]
Benchmarking     random branchlut            ...   22.276ns
Benchmarking sequential branchlut2           ... [   3.450ns,   22.990ns]
Benchmarking     random branchlut2           ...   25.096ns
Benchmarking sequential count                ... [   3.800ns,   36.050ns]
Benchmarking     random count                ...   29.274ns
Benchmarking sequential countlut             ... [   4.630ns,   21.020ns]
Benchmarking     random countlut             ...   21.884ns
Benchmarking sequential fmt                  ... [   3.450ns,   18.170ns]
Benchmarking     random fmt                  ...   20.721ns
Benchmarking sequential jeaiii               ... [   2.760ns,   11.560ns]
Benchmarking     random jeaiii               ...   19.460ns
Benchmarking sequential lut                  ... [   3.450ns,   30.890ns]
Benchmarking     random lut                  ...   26.684ns
Benchmarking sequential mwilson              ... [   3.800ns,   44.410ns]
Benchmarking     random mwilson              ...   33.170ns
Benchmarking sequential naive                ... [   4.500ns,   44.280ns]
Benchmarking     random naive                ...   33.636ns
Benchmarking sequential null                 ... [   2.070ns,    2.070ns]
Benchmarking     random null                 ...    1.734ns
Benchmarking sequential sprintf              ... [  49.480ns,   78.620ns]
Benchmarking     random sprintf              ...   77.953ns
Benchmarking sequential sse2                 ... [   3.110ns,   12.460ns]
Benchmarking     random sse2                 ...   23.627ns
Benchmarking sequential tmueller             ... [   2.760ns,   17.940ns]
Benchmarking     random tmueller             ...   19.528ns
Benchmarking sequential unnamed              ... [   4.830ns,   35.670ns]
Benchmarking     random unnamed              ...   30.056ns
Benchmarking sequential unrolledlut          ... [   4.150ns,   11.420ns]
Benchmarking     random unrolledlut          ...   19.087ns

i64toa
Benchmarking sequential amartin              ... [   3.800ns,   13.140ns]
Benchmarking     random amartin              ...   17.108ns
Benchmarking sequential branchlut            ... [   3.800ns,   20.230ns]
Benchmarking     random branchlut            ...   25.846ns
Benchmarking sequential branchlut2           ... [   4.150ns,   23.140ns]
Benchmarking     random branchlut2           ...   28.305ns
Benchmarking sequential count                ... [   4.150ns,   34.970ns]
Benchmarking     random count                ...   30.927ns
Benchmarking sequential countlut             ... [   5.440ns,   21.110ns]
Benchmarking     random countlut             ...   25.717ns
Benchmarking sequential fmt                  ... [   4.320ns,   19.590ns]
Benchmarking     random fmt                  ...   23.111ns
Benchmarking sequential jeaiii               ... [   3.800ns,   12.130ns]
Benchmarking     random jeaiii               ...   22.672ns
Benchmarking sequential lut                  ... [   4.150ns,   31.400ns]
Benchmarking     random lut                  ...   30.401ns
Benchmarking sequential mwilson              ... [   4.500ns,   60.120ns]
Benchmarking     random mwilson              ...   39.429ns
Benchmarking sequential naive                ... [   4.660ns,   42.900ns]
Benchmarking     random naive                ...   36.632ns
Benchmarking sequential null                 ... [   2.070ns,    2.070ns]
Benchmarking     random null                 ...    1.734ns
Benchmarking sequential sprintf              ... [  51.300ns,   77.990ns]
Benchmarking     random sprintf              ...   83.159ns
Benchmarking sequential sse2                 ... [   3.630ns,   12.120ns]
Benchmarking     random sse2                 ...   26.428ns
Benchmarking sequential tmueller             ... [   2.760ns,   18.210ns]
Benchmarking     random tmueller             ...   19.721ns
Benchmarking sequential unnamed              ... [   6.580ns,   34.810ns]
Benchmarking     random unnamed              ...   33.883ns
Benchmarking sequential unrolledlut          ... [   5.020ns,   12.460ns]
Benchmarking     random unrolledlut          ...   22.335ns
```
</details>