### PR TITLE
Add some benchmarks for fmt::format_to

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,10 @@ endif ()
 
 add_executable(tinyformat_speed_test src/tinyformat-test.cc)
 target_link_libraries(tinyformat_speed_test fmt ${EXTRA_LIBS})
+set_target_properties(tinyformat_speed_test PROPERTIES
+  CXX_STANDARD 20
+  CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS OFF)
 if (HAVE_PROFILER)
   target_link_libraries(tinyformat_speed_test ${PROFILER_LIB})
   set(PROFILE_DEFS ";FMT_PROFILE")
@@ -161,6 +165,12 @@ else()
 	COMMAND @time -p ./tinyformat_speed_test format > /dev/null
 	COMMAND @echo fmt::compile timings:
 	COMMAND @time -p ./tinyformat_speed_test fmt::compile > /dev/null
+  COMMAND @echo fmt::format_to-string timings:
+  COMMAND @time -p ./tinyformat_speed_test fmt::format_to-string > /dev/null
+  COMMAND @echo fmt::format_to-memory_buffer timings:
+  COMMAND @time -p ./tinyformat_speed_test fmt::format_to-memory_buffer > /dev/null
+  COMMAND @echo fmt::format_to-vector_char timings:
+  COMMAND @time -p ./tinyformat_speed_test fmt::format_to-vector_char > /dev/null
 	COMMAND @echo tinyformat timings:
 	COMMAND @time -p ./tinyformat_speed_test tinyformat > /dev/null
 	COMMAND @echo boost timings:

--- a/src/tinyformat-test.cc
+++ b/src/tinyformat-test.cc
@@ -10,6 +10,7 @@ namespace std { class type_info; }
 #include <cstddef>
 
 #ifdef SPEED_TEST
+#include <iterator>
 #ifdef HAVE_FORMAT
 # include "fmt/format.h"
 # include "fmt/compile.h"
@@ -26,6 +27,9 @@ namespace std { class type_info; }
 #include "stb_sprintf.h"
 #include <iomanip>
 #include <stdio.h>
+#include <string>
+#include <string_view>
+#include <vector>
 #endif
 
 // Throw instead of abort() so we can test error conditions.
@@ -128,6 +132,30 @@ void speedTest(const std::string& which)
             *finished_at = '\0';
             std::puts(buf);
         }
+    }
+    else if(which == "fmt::format_to-string" ||
+            which == "fmt::format_to-memory_buffer" ||
+            which == "fmt::format_to-vector_char")
+    {
+        const int x = 42;
+        const double y = 3.14159;
+        const std::string s(3000, 'x');
+        const auto bench = [&](auto&& make) {
+            std::string out;
+            for(long i = 0; i < maxIter; ++i)
+            {
+                auto b = make();
+                fmt::format_to(std::back_inserter(b), "{} {} {}", x, y, s);
+                out.assign(b.data(), b.size());
+            }
+            std::cout << out << "\n";
+        };
+        if(which == "fmt::format_to-string")
+            bench([] { return std::string(); });
+        else if(which == "fmt::format_to-memory_buffer")
+            bench([] { return fmt::memory_buffer(); });
+        else
+            bench([] { return std::vector<char>(); });
     }
 #endif
     else if(which == "folly")


### PR DESCRIPTION
The change to use `-std=c++20` for the speed test is optional. Note that without `CXX_EXTENSIONS OFF`, it will use `gnu++20`.

Demo for https://github.com/fmtlib/fmt/issues/4679. The speedup is significant for `vector<char>`.